### PR TITLE
Add support for tuple deconstruction forms

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -4193,7 +4193,7 @@
         <key>begin</key>
         <string>(?x)
 (?:([_[:alpha:]][_[:alnum:]]*)\s*(:)\s*)?
-(?=[_[:alnum:](])</string>
+(?![,)])</string>
         <key>beginCaptures</key>
         <dict>
           <key>0</key>

--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -451,10 +451,6 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#literal</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#this-or-base-expression</string>
           </dict>
           <dict>
@@ -512,6 +508,10 @@
           <dict>
             <key>include</key>
             <string>#cast-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#literal</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2966,24 +2966,8 @@
                     <key>patterns</key>
                     <array>
                       <dict>
-                        <key>name</key>
-                        <string>punctuation.parenthesis.open.cs</string>
-                        <key>match</key>
-                        <string>\(</string>
-                      </dict>
-                      <dict>
-                        <key>name</key>
-                        <string>punctuation.parenthesis.close.cs</string>
-                        <key>match</key>
-                        <string>\)</string>
-                      </dict>
-                      <dict>
                         <key>include</key>
-                        <string>#tuple-deconstruction-declaration-element</string>
-                      </dict>
-                      <dict>
-                        <key>include</key>
-                        <string>#punctuation-comma</string>
+                        <string>#tuple-declaration-deconstruction-element-list</string>
                       </dict>
                     </array>
                   </dict>
@@ -3517,24 +3501,8 @@
             <key>patterns</key>
             <array>
               <dict>
-                <key>name</key>
-                <string>punctuation.parenthesis.open.cs</string>
-                <key>match</key>
-                <string>\(</string>
-              </dict>
-              <dict>
-                <key>name</key>
-                <string>punctuation.parenthesis.close.cs</string>
-                <key>match</key>
-                <string>\)</string>
-              </dict>
-              <dict>
                 <key>include</key>
-                <string>#tuple-deconstruction-declaration-element</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#punctuation-comma</string>
+                <string>#tuple-declaration-deconstruction-element-list</string>
               </dict>
             </array>
           </dict>
@@ -3553,45 +3521,6 @@
           </dict>
         </array>
       </dict>
-      <key>tuple-deconstruction-declaration-element</key>
-      <dict>
-        <key>match</key>
-        <string>(?x) # e.g. (int x, int y) = GetPoint();
-(?&lt;type-name&gt;
-  (?:
-      (?:(?&lt;identifier&gt;[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
-        \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
-      )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* # Are there any more names being dotted into?
-      (?:\s*\*\s*)* # pointer suffix?
-      (?:\s*\?\s*)? # nullable suffix?
-      (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
-  )|
-  (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
-)?\s*
-\b(\g&lt;identifier&gt;)\b\s*
-(?=[,)])</string>
-        <key>captures</key>
-        <dict>
-          <key>1</key>
-          <dict>
-            <key>patterns</key>
-            <array>
-              <dict>
-                <key>include</key>
-                <string>#type</string>
-              </dict>
-            </array>
-          </dict>
-          <key>6</key>
-          <dict>
-            <key>name</key>
-            <string>entity.name.variable.tuple-element.cs</string>
-          </dict>
-        </dict>
-      </dict>
       <key>tuple-deconstruction-assignment</key>
       <dict>
         <key>match</key>
@@ -3605,91 +3534,112 @@
             <key>patterns</key>
             <array>
               <dict>
-                <key>begin</key>
-                <string>\(</string>
-                <key>beginCaptures</key>
-                <dict>
-                  <key>0</key>
-                  <dict>
-                    <key>name</key>
-                    <string>punctuation.parenthesis.open.cs</string>
-                  </dict>
-                </dict>
-                <key>end</key>
-                <string>\)</string>
-                <key>endCaptures</key>
-                <dict>
-                  <key>0</key>
-                  <dict>
-                    <key>name</key>
-                    <string>punctuation.parenthesis.close.cs</string>
-                  </dict>
-                </dict>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#tuple-deconstruction-assignment-element</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#punctuation-comma</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#tuple-deconstruction-element-list</string>
               </dict>
             </array>
           </dict>
         </dict>
       </dict>
-      <key>tuple-deconstruction-assignment-element</key>
+      <key>tuple-declaration-deconstruction-element-list</key>
       <dict>
+        <key>begin</key>
+        <string>\(</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.open.cs</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>\)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.close.cs</string>
+          </dict>
+        </dict>
         <key>patterns</key>
         <array>
           <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#tuple-declaration-deconstruction-element-list</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#declaration-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#punctuation-comma</string>
+          </dict>
+          <dict>
             <key>match</key>
-            <string>(?x) # e.g. (int x, int y) = GetPoint();
-(?&lt;type-name&gt;
-  (?:
-      (?:(?&lt;identifier&gt;[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
-        \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
-      )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* # Are there any more names being dotted into?
-      (?:\s*\*\s*)* # pointer suffix?
-      (?:\s*\?\s*)? # nullable suffix?
-      (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
-  )|
-  (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
-)\s+
-\b(\g&lt;identifier&gt;)\b\s*
+            <string>(?x) # e.g. x
+\b([_[:alpha:]][_[:alnum:]]*)\b\s*
 (?=[,)])</string>
             <key>captures</key>
             <dict>
               <key>1</key>
-              <dict>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>#type</string>
-                  </dict>
-                </array>
-              </dict>
-              <key>6</key>
               <dict>
                 <key>name</key>
                 <string>entity.name.variable.tuple-element.cs</string>
               </dict>
             </dict>
           </dict>
+        </array>
+      </dict>
+      <key>tuple-deconstruction-element-list</key>
+      <dict>
+        <key>begin</key>
+        <string>\(</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.open.cs</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>\)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.close.cs</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#tuple-deconstruction-element-list</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#declaration-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#punctuation-comma</string>
+          </dict>
           <dict>
             <key>match</key>
-            <string>(?x) # e.g. (x, y) = GetPoint();
+            <string>(?x) # e.g. x
 \b([_[:alpha:]][_[:alnum:]]*)\b\s*
 (?=[,)])</string>
             <key>captures</key>
@@ -3702,6 +3652,53 @@
             </dict>
           </dict>
         </array>
+      </dict>
+      <key>declaration-expression</key>
+      <dict>
+        <key>match</key>
+        <string>(?x) # e.g. int x OR var x
+(?:
+  \b(var)\b|
+  (?&lt;type-name&gt;
+    (?:
+        (?:(?&lt;identifier&gt;[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+          \g&lt;identifier&gt;\s*
+          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        )
+        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* # Are there any more names being dotted into?
+        (?:\s*\*\s*)* # pointer suffix?
+        (?:\s*\?\s*)? # nullable suffix?
+        (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+    )|
+    (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
+  )
+)\s+
+\b(\g&lt;identifier&gt;)\b\s*
+(?=[,)])</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.var.cs</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type</string>
+              </dict>
+            </array>
+          </dict>
+          <key>7</key>
+          <dict>
+            <key>name</key>
+            <string>entity.name.variable.tuple-element.cs</string>
+          </dict>
+        </dict>
       </dict>
       <key>checked-unchecked-expression</key>
       <dict>
@@ -3960,6 +3957,10 @@
             <key>include</key>
             <string>#verbatim-string-literal</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#tuple-literal</string>
+          </dict>
         </array>
       </dict>
       <key>boolean-literal</key>
@@ -4148,6 +4149,73 @@
         <string>constant.character.escape.cs</string>
         <key>match</key>
         <string>""</string>
+      </dict>
+      <key>tuple-literal</key>
+      <dict>
+        <key>begin</key>
+        <string>(\()(?=.*[:,])</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.open.cs</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>\)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.parenthesis.close.cs</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#tuple-literal-element</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#punctuation-comma</string>
+          </dict>
+        </array>
+      </dict>
+      <key>tuple-literal-element</key>
+      <dict>
+        <key>begin</key>
+        <string>(?x)
+(?:([_[:alpha:]][_[:alnum:]]*)\s*(:)\s*)?
+(?=[_[:alnum:](])</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>entity.name.variable.tuple-element.cs</string>
+          </dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.separator.colon.cs</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?=[,)])</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#expression</string>
+          </dict>
+        </array>
       </dict>
       <key>expression-operators</key>
       <dict>

--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -519,6 +519,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#tuple-deconstruction-assignment</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#initializer-expression</string>
           </dict>
           <dict>
@@ -2945,6 +2949,52 @@
                 </dict>
               </dict>
               <dict>
+                <key>match</key>
+                <string>(?x) # match foreach (var (x, y) in ...)
+(?:\b(var)\b\s*)?
+(?&lt;tuple&gt;\((?:[^\(\)]|\g&lt;tuple&gt;)+\))\s+
+\b(in)\b</string>
+                <key>captures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.other.var.cs</string>
+                  </dict>
+                  <key>2</key>
+                  <dict>
+                    <key>patterns</key>
+                    <array>
+                      <dict>
+                        <key>name</key>
+                        <string>punctuation.parenthesis.open.cs</string>
+                        <key>match</key>
+                        <string>\(</string>
+                      </dict>
+                      <dict>
+                        <key>name</key>
+                        <string>punctuation.parenthesis.close.cs</string>
+                        <key>match</key>
+                        <string>\)</string>
+                      </dict>
+                      <dict>
+                        <key>include</key>
+                        <string>#tuple-deconstruction-declaration-element</string>
+                      </dict>
+                      <dict>
+                        <key>include</key>
+                        <string>#punctuation-comma</string>
+                      </dict>
+                    </array>
+                  </dict>
+                  <key>3</key>
+                  <dict>
+                    <key>name</key>
+                    <string>keyword.control.loop.in.cs</string>
+                  </dict>
+                </dict>
+              </dict>
+              <dict>
                 <key>include</key>
                 <string>#expression</string>
               </dict>
@@ -3304,6 +3354,10 @@
             <key>include</key>
             <string>#local-variable-declaration</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#local-tuple-var-deconstruction</string>
+          </dict>
         </array>
       </dict>
       <key>local-variable-declaration</key>
@@ -3441,6 +3495,211 @@
           <dict>
             <key>include</key>
             <string>#variable-initializer</string>
+          </dict>
+        </array>
+      </dict>
+      <key>local-tuple-var-deconstruction</key>
+      <dict>
+        <key>begin</key>
+        <string>(?x) # e.g. var (x, y) = GetPoint();
+(?:\b(var)\b\s*)
+(?&lt;tuple&gt;\((?:[^\(\)]|\g&lt;tuple&gt;)+\))\s*
+(?=;|=|\))</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.var.cs</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>name</key>
+                <string>punctuation.parenthesis.open.cs</string>
+                <key>match</key>
+                <string>\(</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>punctuation.parenthesis.close.cs</string>
+                <key>match</key>
+                <string>\)</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#tuple-deconstruction-declaration-element</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#punctuation-comma</string>
+              </dict>
+            </array>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?=;|\))</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
+          </dict>
+        </array>
+      </dict>
+      <key>tuple-deconstruction-declaration-element</key>
+      <dict>
+        <key>match</key>
+        <string>(?x) # e.g. (int x, int y) = GetPoint();
+(?&lt;type-name&gt;
+  (?:
+      (?:(?&lt;identifier&gt;[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        \g&lt;identifier&gt;\s*
+        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+      )
+      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* # Are there any more names being dotted into?
+      (?:\s*\*\s*)* # pointer suffix?
+      (?:\s*\?\s*)? # nullable suffix?
+      (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+  )|
+  (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
+)?\s*
+\b(\g&lt;identifier&gt;)\b\s*
+(?=[,)])</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type</string>
+              </dict>
+            </array>
+          </dict>
+          <key>6</key>
+          <dict>
+            <key>name</key>
+            <string>entity.name.variable.tuple-element.cs</string>
+          </dict>
+        </dict>
+      </dict>
+      <key>tuple-deconstruction-assignment</key>
+      <dict>
+        <key>match</key>
+        <string>(?x)
+(?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))\s*
+(?!=&gt;|==)(?==)</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>begin</key>
+                <string>\(</string>
+                <key>beginCaptures</key>
+                <dict>
+                  <key>0</key>
+                  <dict>
+                    <key>name</key>
+                    <string>punctuation.parenthesis.open.cs</string>
+                  </dict>
+                </dict>
+                <key>end</key>
+                <string>\)</string>
+                <key>endCaptures</key>
+                <dict>
+                  <key>0</key>
+                  <dict>
+                    <key>name</key>
+                    <string>punctuation.parenthesis.close.cs</string>
+                  </dict>
+                </dict>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#comment</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#tuple-deconstruction-assignment-element</string>
+                  </dict>
+                  <dict>
+                    <key>include</key>
+                    <string>#punctuation-comma</string>
+                  </dict>
+                </array>
+              </dict>
+            </array>
+          </dict>
+        </dict>
+      </dict>
+      <key>tuple-deconstruction-assignment-element</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>match</key>
+            <string>(?x) # e.g. (int x, int y) = GetPoint();
+(?&lt;type-name&gt;
+  (?:
+      (?:(?&lt;identifier&gt;[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        \g&lt;identifier&gt;\s*
+        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+      )
+      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* # Are there any more names being dotted into?
+      (?:\s*\*\s*)* # pointer suffix?
+      (?:\s*\?\s*)? # nullable suffix?
+      (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+  )|
+  (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
+)\s+
+\b(\g&lt;identifier&gt;)\b\s*
+(?=[,)])</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#type</string>
+                  </dict>
+                </array>
+              </dict>
+              <key>6</key>
+              <dict>
+                <key>name</key>
+                <string>entity.name.variable.tuple-element.cs</string>
+              </dict>
+            </dict>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>(?x) # e.g. (x, y) = GetPoint();
+\b([_[:alpha:]][_[:alnum:]]*)\b\s*
+(?=[,)])</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>variable.other.readwrite.cs</string>
+              </dict>
+            </dict>
           </dict>
         </array>
       </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2508,7 +2508,7 @@ repository:
     begin: '''
       (?x)
       (?:([_[:alpha:]][_[:alnum:]]*)\\s*(:)\\s*)?
-      (?=[_[:alnum:](])
+      (?![,)])
     '''
     beginCaptures:
       "0":

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -319,9 +319,6 @@ repository:
         include: "#verbatim-interpolated-string"
       }
       {
-        include: "#literal"
-      }
-      {
         include: "#this-or-base-expression"
       }
       {
@@ -365,6 +362,9 @@ repository:
       }
       {
         include: "#cast-expression"
+      }
+      {
+        include: "#literal"
       }
       {
         include: "#parenthesized-expression"
@@ -1814,18 +1814,7 @@ repository:
               "2":
                 patterns: [
                   {
-                    name: "punctuation.parenthesis.open.cs"
-                    match: "\\("
-                  }
-                  {
-                    name: "punctuation.parenthesis.close.cs"
-                    match: "\\)"
-                  }
-                  {
-                    include: "#tuple-deconstruction-declaration-element"
-                  }
-                  {
-                    include: "#punctuation-comma"
+                    include: "#tuple-declaration-deconstruction-element-list"
                   }
                 ]
               "3":
@@ -2143,18 +2132,7 @@ repository:
       "2":
         patterns: [
           {
-            name: "punctuation.parenthesis.open.cs"
-            match: "\\("
-          }
-          {
-            name: "punctuation.parenthesis.close.cs"
-            match: "\\)"
-          }
-          {
-            include: "#tuple-deconstruction-declaration-element"
-          }
-          {
-            include: "#punctuation-comma"
+            include: "#tuple-declaration-deconstruction-element-list"
           }
         ]
     end: "(?=;|\\))"
@@ -2166,35 +2144,6 @@ repository:
         include: "#variable-initializer"
       }
     ]
-  "tuple-deconstruction-declaration-element":
-    match: '''
-      (?x) # e.g. (int x, int y) = GetPoint();
-      (?<type-name>
-        (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
-              \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
-            )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* # Are there any more names being dotted into?
-            (?:\\s*\\*\\s*)* # pointer suffix?
-            (?:\\s*\\?\\s*)? # nullable suffix?
-            (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
-        )|
-        (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
-      )?\\s*
-      \\b(\\g<identifier>)\\b\\s*
-      (?=[,)])
-    '''
-    captures:
-      "1":
-        patterns: [
-          {
-            include: "#type"
-          }
-        ]
-      "6":
-        name: "entity.name.variable.tuple-element.cs"
   "tuple-deconstruction-assignment":
     match: '''
       (?x)
@@ -2205,62 +2154,67 @@ repository:
       "1":
         patterns: [
           {
-            begin: "\\("
-            beginCaptures:
-              "0":
-                name: "punctuation.parenthesis.open.cs"
-            end: "\\)"
-            endCaptures:
-              "0":
-                name: "punctuation.parenthesis.close.cs"
-            patterns: [
-              {
-                include: "#comment"
-              }
-              {
-                include: "#tuple-deconstruction-assignment-element"
-              }
-              {
-                include: "#punctuation-comma"
-              }
-            ]
+            include: "#tuple-deconstruction-element-list"
           }
         ]
-  "tuple-deconstruction-assignment-element":
+  "tuple-declaration-deconstruction-element-list":
+    begin: "\\("
+    beginCaptures:
+      "0":
+        name: "punctuation.parenthesis.open.cs"
+    end: "\\)"
+    endCaptures:
+      "0":
+        name: "punctuation.parenthesis.close.cs"
     patterns: [
       {
+        include: "#comment"
+      }
+      {
+        include: "#tuple-declaration-deconstruction-element-list"
+      }
+      {
+        include: "#declaration-expression"
+      }
+      {
+        include: "#punctuation-comma"
+      }
+      {
         match: '''
-          (?x) # e.g. (int x, int y) = GetPoint();
-          (?<type-name>
-            (?:
-                (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-                (?<name-and-type-args> # identifier + type arguments (if any)
-                  \\g<identifier>\\s*
-                  (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
-                )
-                (?:\\s*\\.\\s*\\g<name-and-type-args>)* # Are there any more names being dotted into?
-                (?:\\s*\\*\\s*)* # pointer suffix?
-                (?:\\s*\\?\\s*)? # nullable suffix?
-                (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
-            )|
-            (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
-          )\\s+
-          \\b(\\g<identifier>)\\b\\s*
+          (?x) # e.g. x
+          \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
           (?=[,)])
         '''
         captures:
           "1":
-            patterns: [
-              {
-                include: "#type"
-              }
-            ]
-          "6":
             name: "entity.name.variable.tuple-element.cs"
+      }
+    ]
+  "tuple-deconstruction-element-list":
+    begin: "\\("
+    beginCaptures:
+      "0":
+        name: "punctuation.parenthesis.open.cs"
+    end: "\\)"
+    endCaptures:
+      "0":
+        name: "punctuation.parenthesis.close.cs"
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#tuple-deconstruction-element-list"
+      }
+      {
+        include: "#declaration-expression"
+      }
+      {
+        include: "#punctuation-comma"
       }
       {
         match: '''
-          (?x) # e.g. (x, y) = GetPoint();
+          (?x) # e.g. x
           \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
           (?=[,)])
         '''
@@ -2269,6 +2223,40 @@ repository:
             name: "variable.other.readwrite.cs"
       }
     ]
+  "declaration-expression":
+    match: '''
+      (?x) # e.g. int x OR var x
+      (?:
+        \\b(var)\\b|
+        (?<type-name>
+          (?:
+              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?<name-and-type-args> # identifier + type arguments (if any)
+                \\g<identifier>\\s*
+                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              )
+              (?:\\s*\\.\\s*\\g<name-and-type-args>)* # Are there any more names being dotted into?
+              (?:\\s*\\*\\s*)* # pointer suffix?
+              (?:\\s*\\?\\s*)? # nullable suffix?
+              (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
+          )|
+          (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
+        )
+      )\\s+
+      \\b(\\g<identifier>)\\b\\s*
+      (?=[,)])
+    '''
+    captures:
+      "1":
+        name: "keyword.other.var.cs"
+      "2":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+      "7":
+        name: "entity.name.variable.tuple-element.cs"
   "checked-unchecked-expression":
     begin: "(?<!\\.)\\b(?:(checked)|(unchecked))\\b\\s*(\\()"
     beginCaptures:
@@ -2396,6 +2384,9 @@ repository:
       {
         include: "#verbatim-string-literal"
       }
+      {
+        include: "#tuple-literal"
+      }
     ]
   "boolean-literal":
     patterns: [
@@ -2493,6 +2484,43 @@ repository:
   "verbatim-string-character-escape":
     name: "constant.character.escape.cs"
     match: "\"\""
+  "tuple-literal":
+    begin: "(\\()(?=.*[:,])"
+    beginCaptures:
+      "1":
+        name: "punctuation.parenthesis.open.cs"
+    end: "\\)"
+    endCaptures:
+      "0":
+        name: "punctuation.parenthesis.close.cs"
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#tuple-literal-element"
+      }
+      {
+        include: "#punctuation-comma"
+      }
+    ]
+  "tuple-literal-element":
+    begin: '''
+      (?x)
+      (?:([_[:alpha:]][_[:alnum:]]*)\\s*(:)\\s*)?
+      (?=[_[:alnum:](])
+    '''
+    beginCaptures:
+      "0":
+        name: "entity.name.variable.tuple-element.cs"
+      "1":
+        name: "punctuation.separator.colon.cs"
+    end: "(?=[,)])"
+    patterns: [
+      {
+        include: "#expression"
+      }
+    ]
   "expression-operators":
     patterns: [
       {

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -370,6 +370,9 @@ repository:
         include: "#parenthesized-expression"
       }
       {
+        include: "#tuple-deconstruction-assignment"
+      }
+      {
         include: "#initializer-expression"
       }
       {
@@ -1799,6 +1802,36 @@ repository:
                 name: "keyword.control.loop.in.cs"
           }
           {
+            match: '''
+              (?x) # match foreach (var (x, y) in ...)
+              (?:\\b(var)\\b\\s*)?
+              (?<tuple>\\((?:[^\\(\\)]|\\g<tuple>)+\\))\\s+
+              \\b(in)\\b
+            '''
+            captures:
+              "1":
+                name: "keyword.other.var.cs"
+              "2":
+                patterns: [
+                  {
+                    name: "punctuation.parenthesis.open.cs"
+                    match: "\\("
+                  }
+                  {
+                    name: "punctuation.parenthesis.close.cs"
+                    match: "\\)"
+                  }
+                  {
+                    include: "#tuple-deconstruction-declaration-element"
+                  }
+                  {
+                    include: "#punctuation-comma"
+                  }
+                ]
+              "3":
+                name: "keyword.control.loop.in.cs"
+          }
+          {
             include: "#expression"
           }
         ]
@@ -1995,6 +2028,9 @@ repository:
       {
         include: "#local-variable-declaration"
       }
+      {
+        include: "#local-tuple-var-deconstruction"
+      }
     ]
   "local-variable-declaration":
     begin: '''
@@ -2092,6 +2128,145 @@ repository:
       }
       {
         include: "#variable-initializer"
+      }
+    ]
+  "local-tuple-var-deconstruction":
+    begin: '''
+      (?x) # e.g. var (x, y) = GetPoint();
+      (?:\\b(var)\\b\\s*)
+      (?<tuple>\\((?:[^\\(\\)]|\\g<tuple>)+\\))\\s*
+      (?=;|=|\\))
+    '''
+    beginCaptures:
+      "1":
+        name: "keyword.other.var.cs"
+      "2":
+        patterns: [
+          {
+            name: "punctuation.parenthesis.open.cs"
+            match: "\\("
+          }
+          {
+            name: "punctuation.parenthesis.close.cs"
+            match: "\\)"
+          }
+          {
+            include: "#tuple-deconstruction-declaration-element"
+          }
+          {
+            include: "#punctuation-comma"
+          }
+        ]
+    end: "(?=;|\\))"
+    patterns: [
+      {
+        include: "#comment"
+      }
+      {
+        include: "#variable-initializer"
+      }
+    ]
+  "tuple-deconstruction-declaration-element":
+    match: '''
+      (?x) # e.g. (int x, int y) = GetPoint();
+      (?<type-name>
+        (?:
+            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+            (?<name-and-type-args> # identifier + type arguments (if any)
+              \\g<identifier>\\s*
+              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+            )
+            (?:\\s*\\.\\s*\\g<name-and-type-args>)* # Are there any more names being dotted into?
+            (?:\\s*\\*\\s*)* # pointer suffix?
+            (?:\\s*\\?\\s*)? # nullable suffix?
+            (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
+        )|
+        (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
+      )?\\s*
+      \\b(\\g<identifier>)\\b\\s*
+      (?=[,)])
+    '''
+    captures:
+      "1":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+      "6":
+        name: "entity.name.variable.tuple-element.cs"
+  "tuple-deconstruction-assignment":
+    match: '''
+      (?x)
+      (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))\\s*
+      (?!=>|==)(?==)
+    '''
+    captures:
+      "1":
+        patterns: [
+          {
+            begin: "\\("
+            beginCaptures:
+              "0":
+                name: "punctuation.parenthesis.open.cs"
+            end: "\\)"
+            endCaptures:
+              "0":
+                name: "punctuation.parenthesis.close.cs"
+            patterns: [
+              {
+                include: "#comment"
+              }
+              {
+                include: "#tuple-deconstruction-assignment-element"
+              }
+              {
+                include: "#punctuation-comma"
+              }
+            ]
+          }
+        ]
+  "tuple-deconstruction-assignment-element":
+    patterns: [
+      {
+        match: '''
+          (?x) # e.g. (int x, int y) = GetPoint();
+          (?<type-name>
+            (?:
+                (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+                (?<name-and-type-args> # identifier + type arguments (if any)
+                  \\g<identifier>\\s*
+                  (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                )
+                (?:\\s*\\.\\s*\\g<name-and-type-args>)* # Are there any more names being dotted into?
+                (?:\\s*\\*\\s*)* # pointer suffix?
+                (?:\\s*\\?\\s*)? # nullable suffix?
+                (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
+            )|
+            (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
+          )\\s+
+          \\b(\\g<identifier>)\\b\\s*
+          (?=[,)])
+        '''
+        captures:
+          "1":
+            patterns: [
+              {
+                include: "#type"
+              }
+            ]
+          "6":
+            name: "entity.name.variable.tuple-element.cs"
+      }
+      {
+        match: '''
+          (?x) # e.g. (x, y) = GetPoint();
+          \\b([_[:alpha:]][_[:alnum:]]*)\\b\\s*
+          (?=[,)])
+        '''
+        captures:
+          "1":
+            name: "variable.other.readwrite.cs"
       }
     ]
   "checked-unchecked-expression":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -141,7 +141,6 @@ repository:
     - include: '#nameof-expression'
     - include: '#interpolated-string'
     - include: '#verbatim-interpolated-string'
-    - include: '#literal'
     - include: '#this-or-base-expression'
     - include: '#conditional-operator'
     - include: '#expression-operators'
@@ -157,6 +156,7 @@ repository:
     - include: '#invocation-expression'
     - include: '#element-access-expression'
     - include: '#cast-expression'
+    - include: '#literal'
     - include: '#parenthesized-expression'
     - include: '#tuple-deconstruction-assignment'
     - include: '#initializer-expression'
@@ -1088,12 +1088,7 @@ repository:
           '1': { name: keyword.other.var.cs }
           '2':
             patterns:
-            - name: punctuation.parenthesis.open.cs 
-              match: \(
-            - name: punctuation.parenthesis.close.cs
-              match: \)
-            - include: '#tuple-deconstruction-declaration-element'
-            - include: '#punctuation-comma'
+            - include: '#tuple-declaration-deconstruction-element-list'
           '3': { name: keyword.control.loop.in.cs }
       - include: '#expression'
     - include: '#statement'
@@ -1315,45 +1310,11 @@ repository:
       '1': { name: keyword.other.var.cs }
       '2':
         patterns:
-        - name: punctuation.parenthesis.open.cs 
-          match: \(
-        - name: punctuation.parenthesis.close.cs
-          match: \)
-        - include: '#tuple-deconstruction-declaration-element'
-        - include: '#punctuation-comma'
+        - include: '#tuple-declaration-deconstruction-element-list'
     end: (?=;|\))
     patterns:
     - include: '#comment'
     - include: '#variable-initializer'
-
-  tuple-deconstruction-declaration-element:
-    match: |-
-      (?x) # e.g. (int x, int y) = GetPoint();
-      (?<type-name>
-        (?:
-            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
-              \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
-            )
-            (?:\s*\.\s*\g<name-and-type-args>)* # Are there any more names being dotted into?
-            (?:\s*\*\s*)* # pointer suffix?
-            (?:\s*\?\s*)? # nullable suffix?
-            (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
-        )|
-        (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
-      )?\s*
-      \b(\g<identifier>)\b\s*
-      (?=[,)])
-    captures:
-      '1':
-        patterns:
-        - include: '#type'
-      # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '4': ?<type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<tuple> is a sub-expression. It's final value is not considered.
-      '6': { name: entity.name.variable.tuple-element.cs }
 
   tuple-deconstruction-assignment:
     match: |-
@@ -1363,21 +1324,51 @@ repository:
     captures:
       '1':
         patterns:
-        - begin: \(
-          beginCaptures:
-            '0': { name: punctuation.parenthesis.open.cs }
-          end: \)
-          endCaptures:
-            '0': { name: punctuation.parenthesis.close.cs }
-          patterns:
-          - include: '#comment'
-          - include: '#tuple-deconstruction-assignment-element'
-          - include: '#punctuation-comma'
+        - include: '#tuple-deconstruction-element-list'
 
-  tuple-deconstruction-assignment-element:
+  tuple-declaration-deconstruction-element-list:
+    begin: \(
+    beginCaptures:
+      '0': { name: punctuation.parenthesis.open.cs }
+    end: \)
+    endCaptures:
+      '0': { name: punctuation.parenthesis.close.cs }
     patterns:
+    - include: '#comment'
+    - include: '#tuple-declaration-deconstruction-element-list'
+    - include: '#declaration-expression'
+    - include: '#punctuation-comma'
     - match: |-
-        (?x) # e.g. (int x, int y) = GetPoint();
+        (?x) # e.g. x
+        \b([_[:alpha:]][_[:alnum:]]*)\b\s*
+        (?=[,)])
+      captures:
+        '1': { name: entity.name.variable.tuple-element.cs }
+
+  tuple-deconstruction-element-list:
+    begin: \(
+    beginCaptures:
+      '0': { name: punctuation.parenthesis.open.cs }
+    end: \)
+    endCaptures:
+      '0': { name: punctuation.parenthesis.close.cs }
+    patterns:
+    - include: '#comment'
+    - include: '#tuple-deconstruction-element-list'
+    - include: '#declaration-expression'
+    - include: '#punctuation-comma'
+    - match: |-
+        (?x) # e.g. x
+        \b([_[:alpha:]][_[:alnum:]]*)\b\s*
+        (?=[,)])
+      captures:
+        '1': { name: variable.other.readwrite.cs }
+
+  declaration-expression:
+    match: |-
+      (?x) # e.g. int x OR var x
+      (?:
+        \b(var)\b|
         (?<type-name>
           (?:
               (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
@@ -1391,24 +1382,20 @@ repository:
               (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )|
           (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
-        )\s+
-        \b(\g<identifier>)\b\s*
-        (?=[,)])
-      captures:
-        '1':
-          patterns:
-          - include: '#type'
-        # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-        # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-        # '4': ?<type-args> is a sub-expression. It's final value is not considered.
-        # '5': ?<tuple> is a sub-expression. It's final value is not considered.
-        '6': { name: entity.name.variable.tuple-element.cs }
-    - match: |-
-        (?x) # e.g. (x, y) = GetPoint();
-        \b([_[:alpha:]][_[:alnum:]]*)\b\s*
-        (?=[,)])
-      captures:
-        '1': { name: variable.other.readwrite.cs }
+        )
+      )\s+
+      \b(\g<identifier>)\b\s*
+      (?=[,)])
+    captures:
+      '1': { name: keyword.other.var.cs }
+      '2':
+        patterns:
+        - include: '#type'
+      # '3': ?<identifier> is a sub-expression. It's final value is not considered.
+      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '6': ?<tuple> is a sub-expression. It's final value is not considered.
+      '7': { name: entity.name.variable.tuple-element.cs }
 
   checked-unchecked-expression:
     begin: (?<!\.)\b(?:(checked)|(unchecked))\b\s*(\()
@@ -1490,6 +1477,7 @@ repository:
     - include: '#char-literal'
     - include: '#string-literal'
     - include: '#verbatim-string-literal'
+    - include: '#tuple-literal'
 
   boolean-literal:
     patterns:
@@ -1564,6 +1552,30 @@ repository:
   verbatim-string-character-escape:
     name: constant.character.escape.cs
     match: '""'
+
+  tuple-literal:
+    begin: (\()(?=.*[:,])
+    beginCaptures:
+      '1': { name: punctuation.parenthesis.open.cs }
+    end: \)
+    endCaptures:
+      '0': { name: punctuation.parenthesis.close.cs }
+    patterns:
+    - include: '#comment'
+    - include: '#tuple-literal-element'
+    - include: '#punctuation-comma'
+
+  tuple-literal-element:
+    begin: |-
+      (?x)
+      (?:([_[:alpha:]][_[:alnum:]]*)\s*(:)\s*)?
+      (?=[_[:alnum:](])
+    beginCaptures:
+      '0': { name: entity.name.variable.tuple-element.cs }
+      '1': { name: punctuation.separator.colon.cs }
+    end: (?=[,)])
+    patterns:
+    - include: '#expression'
 
   expression-operators:
     patterns:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1569,7 +1569,7 @@ repository:
     begin: |-
       (?x)
       (?:([_[:alpha:]][_[:alnum:]]*)\s*(:)\s*)?
-      (?=[_[:alnum:](])
+      (?![,)])
     beginCaptures:
       '0': { name: entity.name.variable.tuple-element.cs }
       '1': { name: punctuation.separator.colon.cs }

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -158,6 +158,7 @@ repository:
     - include: '#element-access-expression'
     - include: '#cast-expression'
     - include: '#parenthesized-expression'
+    - include: '#tuple-deconstruction-assignment'
     - include: '#initializer-expression'
     - include: '#identifier'
 
@@ -1078,6 +1079,22 @@ repository:
           # '6': ?<tuple> is a sub-expression. It's final value is not considered.
           '7': { name: entity.name.variable.local.cs }
           '8': { name: keyword.control.loop.in.cs }
+      - match: |-
+          (?x) # match foreach (var (x, y) in ...)
+          (?:\b(var)\b\s*)?
+          (?<tuple>\((?:[^\(\)]|\g<tuple>)+\))\s+
+          \b(in)\b
+        captures:
+          '1': { name: keyword.other.var.cs }
+          '2':
+            patterns:
+            - name: punctuation.parenthesis.open.cs 
+              match: \(
+            - name: punctuation.parenthesis.close.cs
+              match: \)
+            - include: '#tuple-deconstruction-declaration-element'
+            - include: '#punctuation-comma'
+          '3': { name: keyword.control.loop.in.cs }
       - include: '#expression'
     - include: '#statement'
 
@@ -1208,6 +1225,7 @@ repository:
     patterns:
     - include: '#local-constant-declaration'
     - include: '#local-variable-declaration'
+    - include: '#local-tuple-var-deconstruction'
 
   local-variable-declaration:
     begin: |-
@@ -1286,6 +1304,111 @@ repository:
     - include: '#punctuation-comma'
     - include: '#comment'
     - include: '#variable-initializer'
+
+  local-tuple-var-deconstruction:
+    begin: |-
+      (?x) # e.g. var (x, y) = GetPoint();
+      (?:\b(var)\b\s*)
+      (?<tuple>\((?:[^\(\)]|\g<tuple>)+\))\s*
+      (?=;|=|\))
+    beginCaptures:
+      '1': { name: keyword.other.var.cs }
+      '2':
+        patterns:
+        - name: punctuation.parenthesis.open.cs 
+          match: \(
+        - name: punctuation.parenthesis.close.cs
+          match: \)
+        - include: '#tuple-deconstruction-declaration-element'
+        - include: '#punctuation-comma'
+    end: (?=;|\))
+    patterns:
+    - include: '#comment'
+    - include: '#variable-initializer'
+
+  tuple-deconstruction-declaration-element:
+    match: |-
+      (?x) # e.g. (int x, int y) = GetPoint();
+      (?<type-name>
+        (?:
+            (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+            (?<name-and-type-args> # identifier + type arguments (if any)
+              \g<identifier>\s*
+              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+            )
+            (?:\s*\.\s*\g<name-and-type-args>)* # Are there any more names being dotted into?
+            (?:\s*\*\s*)* # pointer suffix?
+            (?:\s*\?\s*)? # nullable suffix?
+            (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+        )|
+        (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
+      )?\s*
+      \b(\g<identifier>)\b\s*
+      (?=[,)])
+    captures:
+      '1':
+        patterns:
+        - include: '#type'
+      # '2': ?<identifier> is a sub-expression. It's final value is not considered.
+      # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '5': ?<tuple> is a sub-expression. It's final value is not considered.
+      '6': { name: entity.name.variable.tuple-element.cs }
+
+  tuple-deconstruction-assignment:
+    match: |-
+      (?x)
+      (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))\s*
+      (?!=>|==)(?==)
+    captures:
+      '1':
+        patterns:
+        - begin: \(
+          beginCaptures:
+            '0': { name: punctuation.parenthesis.open.cs }
+          end: \)
+          endCaptures:
+            '0': { name: punctuation.parenthesis.close.cs }
+          patterns:
+          - include: '#comment'
+          - include: '#tuple-deconstruction-assignment-element'
+          - include: '#punctuation-comma'
+
+  tuple-deconstruction-assignment-element:
+    patterns:
+    - match: |-
+        (?x) # e.g. (int x, int y) = GetPoint();
+        (?<type-name>
+          (?:
+              (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+              (?<name-and-type-args> # identifier + type arguments (if any)
+                \g<identifier>\s*
+                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              )
+              (?:\s*\.\s*\g<name-and-type-args>)* # Are there any more names being dotted into?
+              (?:\s*\*\s*)* # pointer suffix?
+              (?:\s*\?\s*)? # nullable suffix?
+              (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
+          )|
+          (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
+        )\s+
+        \b(\g<identifier>)\b\s*
+        (?=[,)])
+      captures:
+        '1':
+          patterns:
+          - include: '#type'
+        # '2': ?<identifier> is a sub-expression. It's final value is not considered.
+        # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
+        # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+        # '5': ?<tuple> is a sub-expression. It's final value is not considered.
+        '6': { name: entity.name.variable.tuple-element.cs }
+    - match: |-
+        (?x) # e.g. (x, y) = GetPoint();
+        \b([_[:alpha:]][_[:alnum:]]*)\b\s*
+        (?=[,)])
+      captures:
+        '1': { name: variable.other.readwrite.cs }
 
   checked-unchecked-expression:
     begin: (?<!\.)\b(?:(checked)|(unchecked))\b\s*(\()

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -809,6 +809,28 @@ describe("Grammar", () => {
                 ]);
             });
 
+            it("cast to tuple type in assignment", () => {
+                const input = Input.InMethod(`var t = ((int x, int y))o;`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Var,
+                    Token.Identifiers.LocalName("t"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.OpenParen,
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.TupleElementName("x"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.TupleElementName("y"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.CloseParen,
+                    Token.Variables.ReadWrite("o"),
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+
             it("passed to invocation", () => {
                 const input = Input.InMethod(`M((int)42);`);
                 const tokens = tokenize(input);

--- a/test/tuple.tests.ts
+++ b/test/tuple.tests.ts
@@ -9,6 +9,25 @@ import { tokenize, Input, Token } from './utils/tokenize';
 describe("Grammar", () => {
     before(() => should());
     describe("Tuples", () => {
+        it("Tuple literal", () => {
+            const input = Input.InMethod(`var p = (42, "hello");`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Var,
+                Token.Identifiers.LocalName("p"),
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("42"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.String.Begin,
+                Token.Literals.String("hello"),
+                Token.Punctuation.String.End,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
         it("Assign to tuple variable", () => {
             const input = Input.InMethod(`(int x, int y) p = point;`);
             const tokens = tokenize(input);

--- a/test/tuple.tests.ts
+++ b/test/tuple.tests.ts
@@ -9,7 +9,26 @@ import { tokenize, Input, Token } from './utils/tokenize';
 describe("Grammar", () => {
     before(() => should());
     describe("Tuples", () => {
-        it("Deconstruct into new tuple", () => {
+        it("Assign to tuple variable", () => {
+            const input = Input.InMethod(`(int x, int y) p = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Identifiers.LocalName("p"),
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct into new locals", () => {
             const input = Input.InMethod(`(int x, int y) = point;`);
             const tokens = tokenize(input);
 
@@ -43,7 +62,7 @@ describe("Grammar", () => {
             ]);
         });
 
-        it("Deconstruct into new tuple with var", () => {
+        it("Deconstruct into new locals with single var", () => {
             const input = Input.InMethod(`var (x, y) = point;`);
             const tokens = tokenize(input);
 
@@ -60,8 +79,53 @@ describe("Grammar", () => {
             ]);
         });
 
-        it("Assign to tuple variable", () => {
-            const input = Input.InMethod(`(int x, int y) p = point;`);
+        it("Deconstruct into new locals with multiple vars", () => {
+            const input = Input.InMethod(`(var x, var y) = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct into new locals with mixed type names and var", () => {
+            const input = Input.InMethod(`(string x, byte y, var z) = (null, 1, 2);`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.String,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Byte,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Null,
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("1"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("2"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct nested tuple into new locals", () => {
+            const input = Input.InMethod(`(int x, (int y, int z)) = (17, (2, 23));`);
             const tokens = tokenize(input);
 
             tokens.should.deep.equal([
@@ -69,12 +133,84 @@ describe("Grammar", () => {
                 Token.PrimitiveType.Int,
                 Token.Identifiers.TupleElementName("x"),
                 Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
                 Token.PrimitiveType.Int,
                 Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("z"),
                 Token.Punctuation.CloseParen,
-                Token.Identifiers.LocalName("p"),
+                Token.Punctuation.CloseParen,
                 Token.Operators.Assignment,
-                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("17"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("2"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("23"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct nested tuple into new locals with multiple vars", () => {
+            const input = Input.InMethod(`(var x, (var y, var z)) = (17, (2, 23));`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("17"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("2"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("23"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct nested tuple into new locals with var", () => {
+            const input = Input.InMethod(`var (x, (y, z)) = (17, (2, 23));`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Var,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("17"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("2"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("23"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
                 Token.Punctuation.Semicolon
             ]);
         });
@@ -118,6 +254,85 @@ describe("Grammar", () => {
                 Token.Keywords.Control.In,
                 Token.Identifiers.MethodName("GetPoints"),
                 Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+
+        it("Deconstruct into new nested tuple in foreach", () => {
+            const input = Input.InMethod(`foreach ((int x, (int y, int z)) in data) { }`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Control.ForEach,
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Keywords.Control.In,
+                Token.Variables.ReadWrite("data"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+
+        it("Deconstruct into new nested tuple with multiple vars in foreach", () => {
+            const input = Input.InMethod(`foreach ((var x, (var y, var z)) in data) { }`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Control.ForEach,
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.Keywords.Var,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Keywords.Control.In,
+                Token.Variables.ReadWrite("data"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+
+        it("Deconstruct into new nested tuple with with var in foreach", () => {
+            const input = Input.InMethod(`foreach (var (x, (y, z)) in data) { }`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Control.ForEach,
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.Comma,
+                Token.Identifiers.TupleElementName("z"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Keywords.Control.In,
+                Token.Variables.ReadWrite("data"),
                 Token.Punctuation.CloseParen,
                 Token.Punctuation.OpenBrace,
                 Token.Punctuation.CloseBrace

--- a/test/tuple.tests.ts
+++ b/test/tuple.tests.ts
@@ -28,6 +28,49 @@ describe("Grammar", () => {
             ]);
         });
 
+        it("Deconstruct tuple into new locals", () => {
+            const input = Input.InMethod(`(int x, int y) = (19, 23);`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("19"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("23"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct tuple into new local and discard", () => {
+            const input = Input.InMethod(`(int x, _) = (19, 23);`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Variables.ReadWrite("_"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Literals.Numeric.Decimal("19"),
+                Token.Punctuation.Comma,
+                Token.Literals.Numeric.Decimal("23"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
         it("Deconstruct into new locals", () => {
             const input = Input.InMethod(`(int x, int y) = point;`);
             const tokens = tokenize(input);

--- a/test/tuple.tests.ts
+++ b/test/tuple.tests.ts
@@ -1,0 +1,127 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { should } from 'chai';
+import { tokenize, Input, Token } from './utils/tokenize';
+
+describe("Grammar", () => {
+    before(() => should());
+    describe("Tuples", () => {
+        it("Deconstruct into new tuple", () => {
+            const input = Input.InMethod(`(int x, int y) = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct into existing variables", () => {
+            const input = Input.InMethod(`(x, y) = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.Variables.ReadWrite("x"),
+                Token.Punctuation.Comma,
+                Token.Variables.ReadWrite("y"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct into new tuple with var", () => {
+            const input = Input.InMethod(`var (x, y) = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Var,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Assign to tuple variable", () => {
+            const input = Input.InMethod(`(int x, int y) p = point;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Identifiers.LocalName("p"),
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("point"),
+                Token.Punctuation.Semicolon
+            ]);
+        });
+
+        it("Deconstruct into new tuple in foreach", () => {
+            const input = Input.InMethod(`foreach ((int x, int y) in GetPoints() { }`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Control.ForEach,
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Keywords.Control.In,
+                Token.Identifiers.MethodName("GetPoints"),
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+
+        it("Deconstruct into new tuple with var in foreach", () => {
+            const input = Input.InMethod(`foreach (var (x, y) in GetPoints() { }`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Control.ForEach,
+                Token.Punctuation.OpenParen,
+                Token.Keywords.Var,
+                Token.Punctuation.OpenParen,
+                Token.Identifiers.TupleElementName("x"),
+                Token.Punctuation.Comma,
+                Token.Identifiers.TupleElementName("y"),
+                Token.Punctuation.CloseParen,
+                Token.Keywords.Control.In,
+                Token.Identifiers.MethodName("GetPoints"),
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+    });
+});

--- a/test/type-name.tests.ts
+++ b/test/type-name.tests.ts
@@ -76,6 +76,45 @@ describe("Grammar", () => {
                 Token.Punctuation.Semicolon]);
         });
 
+        it("nested tuple type - (int, (int, int))", () => {
+            const input = Input.InClass(`(int, (int, int)) x;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Identifiers.FieldName("x"),
+                Token.Punctuation.Semicolon]);
+        });
+
+        it("nested tuple type with element names - (int i, (int j, int k))", () => {
+            const input = Input.InClass(`(int i, (int j, int k)) x;`);
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("i"),
+                Token.Punctuation.Comma,
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("j"),
+                Token.Punctuation.Comma,
+                Token.PrimitiveType.Int,
+                Token.Identifiers.TupleElementName("k"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.CloseParen,
+                Token.Identifiers.FieldName("x"),
+                Token.Punctuation.Semicolon]);
+        });
+
         it("generic type - List<int>", () => {
             const input = Input.InClass(`List<int> x;`);
             const tokens = tokenize(input);


### PR DESCRIPTION
Fixes #8

With this change, we support the following C# 7 tuple deconstruction forms in our TextMate grammar. @madstorgersen, @jcouv: This is based on my memory from past design meetings. Given that there's no official spec yet, could you let me know if I'm missing anything?

1. Deconstruct into new locals.
    ```C#
    (int x, int y) = GetPoint();
    ```

2. Deconstruct into new locals (type-inferred).
    ```C#
    var (x, y) = GetPoint();
    ```

3. Assign into existing locals.
    ```C#
    int x, y;
    (x, y) = GetPoint();
    ```

4. Deconstruct into new iteration variables in foreach statement.
    ```C#
    foreach ((int x, int y) in GetPoints() { }
    ```

5. Deconstruct into new iteration variables in foreach statement (type-inferred).
    ```C#
    foreach (var (x, y) in GetPoints() { }
    ```