### PR TITLE
Ensure that we still match class or struct members when a semicolon is missing

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -141,7 +141,7 @@
           </dict>
         </array>
       </dict>
-      <key>class-members</key>
+      <key>class-or-struct-members</key>
       <dict>
         <key>patterns</key>
         <array>
@@ -163,73 +163,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#event-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#property-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#indexer-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#field-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#variable-initializer</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#constructor-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#destructor-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#operator-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#conversion-operator-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#method-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#attribute-section</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#punctuation-semicolon</string>
-          </dict>
-        </array>
-      </dict>
-      <key>struct-members</key>
-      <dict>
-        <key>patterns</key>
-        <array>
-          <dict>
-            <key>include</key>
-            <string>#preprocessor</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#comment</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#storage-modifier</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#type-declarations</string>
           </dict>
           <dict>
             <key>include</key>
@@ -242,10 +176,6 @@
           <dict>
             <key>include</key>
             <string>#indexer-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#field-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -924,7 +854,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#class-members</string>
+                <string>#class-or-struct-members</string>
               </dict>
             </array>
           </dict>
@@ -1294,7 +1224,7 @@
             <array>
               <dict>
                 <key>include</key>
-                <string>#struct-members</string>
+                <string>#class-or-struct-members</string>
               </dict>
             </array>
           </dict>
@@ -1489,7 +1419,7 @@
   (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
 )\s+
 (\g&lt;identifier&gt;)\s* # first field name
-(?!=&gt;|==)(?=,|;|=)</string>
+(?!=&gt;|==)(?=,|;|=|$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1529,6 +1459,10 @@
           <dict>
             <key>include</key>
             <string>#variable-initializer</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#class-or-struct-members</string>
           </dict>
         </array>
       </dict>
@@ -1607,6 +1541,10 @@
           <dict>
             <key>include</key>
             <string>#variable-initializer</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#class-or-struct-members</string>
           </dict>
         </array>
       </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -94,7 +94,7 @@ repository:
         include: "#punctuation-semicolon"
       }
     ]
-  "class-members":
+  "class-or-struct-members":
     patterns: [
       {
         include: "#preprocessor"
@@ -109,55 +109,7 @@ repository:
         include: "#type-declarations"
       }
       {
-        include: "#event-declaration"
-      }
-      {
-        include: "#property-declaration"
-      }
-      {
-        include: "#indexer-declaration"
-      }
-      {
         include: "#field-declaration"
-      }
-      {
-        include: "#variable-initializer"
-      }
-      {
-        include: "#constructor-declaration"
-      }
-      {
-        include: "#destructor-declaration"
-      }
-      {
-        include: "#operator-declaration"
-      }
-      {
-        include: "#conversion-operator-declaration"
-      }
-      {
-        include: "#method-declaration"
-      }
-      {
-        include: "#attribute-section"
-      }
-      {
-        include: "#punctuation-semicolon"
-      }
-    ]
-  "struct-members":
-    patterns: [
-      {
-        include: "#preprocessor"
-      }
-      {
-        include: "#comment"
-      }
-      {
-        include: "#storage-modifier"
-      }
-      {
-        include: "#type-declarations"
       }
       {
         include: "#event-declaration"
@@ -167,9 +119,6 @@ repository:
       }
       {
         include: "#indexer-declaration"
-      }
-      {
-        include: "#field-declaration"
       }
       {
         include: "#variable-initializer"
@@ -593,7 +542,7 @@ repository:
             name: "punctuation.curlybrace.close.cs"
         patterns: [
           {
-            include: "#class-members"
+            include: "#class-or-struct-members"
           }
         ]
       }
@@ -820,7 +769,7 @@ repository:
             name: "punctuation.curlybrace.close.cs"
         patterns: [
           {
-            include: "#struct-members"
+            include: "#class-or-struct-members"
           }
         ]
       }
@@ -934,7 +883,7 @@ repository:
         (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
       )\\s+
       (\\g<identifier>)\\s* # first field name
-      (?!=>|==)(?=,|;|=)
+      (?!=>|==)(?=,|;|=|$)
     '''
     beginCaptures:
       "1":
@@ -959,6 +908,9 @@ repository:
       }
       {
         include: "#variable-initializer"
+      }
+      {
+        include: "#class-or-struct-members"
       }
     ]
   "property-declaration":
@@ -1016,6 +968,9 @@ repository:
       }
       {
         include: "#variable-initializer"
+      }
+      {
+        include: "#class-or-struct-members"
       }
     ]
   "indexer-declaration":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -57,35 +57,16 @@ repository:
     - include: '#attribute-section'
     - include: '#punctuation-semicolon'
 
-  class-members:
+  class-or-struct-members:
     patterns:
     - include: '#preprocessor'
     - include: '#comment'
     - include: '#storage-modifier'
     - include: '#type-declarations'
+    - include: '#field-declaration'
     - include: '#event-declaration'
     - include: '#property-declaration'
     - include: '#indexer-declaration'
-    - include: '#field-declaration'
-    - include: '#variable-initializer'
-    - include: '#constructor-declaration'
-    - include: '#destructor-declaration'
-    - include: '#operator-declaration'
-    - include: '#conversion-operator-declaration'
-    - include: '#method-declaration'
-    - include: '#attribute-section'
-    - include: '#punctuation-semicolon'
-
-  struct-members:
-    patterns:
-    - include: '#preprocessor'
-    - include: '#comment'
-    - include: '#storage-modifier'
-    - include: '#type-declarations'
-    - include: '#event-declaration'
-    - include: '#property-declaration'
-    - include: '#indexer-declaration'
-    - include: '#field-declaration'
     - include: '#variable-initializer'
     - include: '#constructor-declaration'
     - include: '#destructor-declaration'
@@ -286,7 +267,7 @@ repository:
       endCaptures:
         '0': { name: punctuation.curlybrace.close.cs }
       patterns:
-      - include: '#class-members'
+      - include: '#class-or-struct-members'
     - include: '#preprocessor'
     - include: '#comment'
 
@@ -418,7 +399,7 @@ repository:
       endCaptures:
         '0': { name: punctuation.curlybrace.close.cs }
       patterns:
-      - include: '#struct-members'
+      - include: '#class-or-struct-members'
     - include: '#preprocessor'
     - include: '#comment'
 
@@ -488,7 +469,7 @@ repository:
         (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
       )\s+
       (\g<identifier>)\s* # first field name
-      (?!=>|==)(?=,|;|=)
+      (?!=>|==)(?=,|;|=|$)
     beginCaptures:
       '1':
         patterns:
@@ -505,6 +486,7 @@ repository:
     - include: '#punctuation-comma'
     - include: '#comment'
     - include: '#variable-initializer'
+    - include: '#class-or-struct-members'
 
   property-declaration:
     begin: |-
@@ -549,6 +531,7 @@ repository:
     - include: '#property-accessors'
     - include: '#expression-body'
     - include: '#variable-initializer'
+    - include: '#class-or-struct-members'
 
   indexer-declaration:
     begin: |-

--- a/test/incomplete-code.tests.ts
+++ b/test/incomplete-code.tests.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { should } from 'chai';
+import { tokenize, Input, Token } from './utils/tokenize';
+
+describe("Grammar", () => {
+    before(() => should());
+
+    describe("Incomplete code", () => {
+        it("Don't eat the next lines if there isn't a semicolon (issue #15)", () => {
+            const input = Input.InClass(`
+private readonly string _color
+public ColorTest(string white)
+{
+    _color = white;
+}
+`);
+
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Modifiers.Private,
+                Token.Keywords.Modifiers.ReadOnly,
+                Token.PrimitiveType.String,
+                Token.Identifiers.PropertyName("_color"),
+                Token.Keywords.Modifiers.Public,
+                Token.Identifiers.MethodName("ColorTest"),
+                Token.Punctuation.OpenParen,
+                Token.PrimitiveType.String,
+                Token.Identifiers.ParameterName("white"),
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Variables.ReadWrite("_color"),
+                Token.Operators.Assignment,
+                Token.Variables.ReadWrite("white"),
+                Token.Punctuation.Semicolon,
+                Token.Punctuation.CloseBrace
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #15 

Here's what it looks like with this change:

![image](https://cloud.githubusercontent.com/assets/116161/22373953/dce61886-e458-11e6-92ed-5f5df58a0703.png)

cc @tverboon