### PR TITLE
added support for #load and #r

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6270,6 +6270,14 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#preprocessor-load</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#preprocessor-r</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#preprocessor-endregion</string>
           </dict>
           <dict>
@@ -6378,6 +6386,42 @@
           <dict>
             <key>name</key>
             <string>string.unquoted.preprocessor.message.cs</string>
+          </dict>
+        </dict>
+      </dict>
+      <key>preprocessor-load</key>
+      <dict>
+        <key>match</key>
+        <string>\b(load)\b\s*(\"[^"]*\")</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.preprocessor.load.cs</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>string.quoted.double.cs</string>
+          </dict>
+        </dict>
+      </dict>
+      <key>preprocessor-r</key>
+      <dict>
+        <key>match</key>
+        <string>\b(r)\b\s*(\"[^"]*\")</string>
+        <key>captures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.preprocessor.r.cs</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>string.quoted.double.cs</string>
           </dict>
         </dict>
       </dict>

--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6270,15 +6270,15 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#preprocessor-endregion</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#preprocessor-load</string>
           </dict>
           <dict>
             <key>include</key>
             <string>#preprocessor-r</string>
-          </dict>
-          <dict>
-            <key>include</key>
-            <string>#preprocessor-endregion</string>
           </dict>
           <dict>
             <key>include</key>
@@ -6391,39 +6391,63 @@
       </dict>
       <key>preprocessor-load</key>
       <dict>
-        <key>match</key>
-        <string>\b(load)\b\s*(\"[^"]*\")</string>
-        <key>captures</key>
+        <key>begin</key>
+        <string>\b(load)\b</string>
+        <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
             <string>keyword.preprocessor.load.cs</string>
           </dict>
-          <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>string.quoted.double.cs</string>
-          </dict>
         </dict>
+        <key>end</key>
+        <string>(?=$)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>match</key>
+            <string>\"[^"]*\"</string>
+            <key>captures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.double.cs</string>
+              </dict>
+            </dict>
+          </dict>
+        </array>
       </dict>
       <key>preprocessor-r</key>
       <dict>
-        <key>match</key>
-        <string>\b(r)\b\s*(\"[^"]*\")</string>
-        <key>captures</key>
+        <key>begin</key>
+        <string>\b(r)\b</string>
+        <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
             <string>keyword.preprocessor.r.cs</string>
           </dict>
-          <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>string.quoted.double.cs</string>
-          </dict>
         </dict>
+        <key>end</key>
+        <string>(?=$)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>match</key>
+            <string>\"[^"]*\"</string>
+            <key>captures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.double.cs</string>
+              </dict>
+            </dict>
+          </dict>
+        </array>
       </dict>
       <key>preprocessor-region</key>
       <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3779,13 +3779,13 @@ repository:
         include: "#preprocessor-region"
       }
       {
+        include: "#preprocessor-endregion"
+      }
+      {
         include: "#preprocessor-load"
       }
       {
         include: "#preprocessor-r"
-      }
-      {
-        include: "#preprocessor-endregion"
       }
       {
         include: "#preprocessor-line"
@@ -3839,19 +3839,33 @@ repository:
       "3":
         name: "string.unquoted.preprocessor.message.cs"
   "preprocessor-load":
-    match: "\\b(load)\\b\\s*(\\\"[^\"]*\\\")"
-    captures:
+    begin: "\\b(load)\\b"
+    beginCaptures:
       "1":
         name: "keyword.preprocessor.load.cs"
-      "2":
-        name: "string.quoted.double.cs"
+    end: "(?=$)"
+    patterns: [
+      {
+        match: "\\\"[^\"]*\\\""
+        captures:
+          "0":
+            name: "string.quoted.double.cs"
+      }
+    ]
   "preprocessor-r":
-    match: "\\b(r)\\b\\s*(\\\"[^\"]*\\\")"
-    captures:
+    begin: "\\b(r)\\b"
+    beginCaptures:
       "1":
         name: "keyword.preprocessor.r.cs"
-      "2":
-        name: "string.quoted.double.cs"
+    end: "(?=$)"
+    patterns: [
+      {
+        match: "\\\"[^\"]*\\\""
+        captures:
+          "0":
+            name: "string.quoted.double.cs"
+      }
+    ]
   "preprocessor-region":
     match: "\\b(region)\\b\\s*(.*)(?=$)"
     captures:

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3779,6 +3779,12 @@ repository:
         include: "#preprocessor-region"
       }
       {
+        include: "#preprocessor-load"
+      }
+      {
+        include: "#preprocessor-r"
+      }
+      {
         include: "#preprocessor-endregion"
       }
       {
@@ -3832,6 +3838,20 @@ repository:
         name: "keyword.preprocessor.error.cs"
       "3":
         name: "string.unquoted.preprocessor.message.cs"
+  "preprocessor-load":
+    match: "\\b(load)\\b\\s*(\\\"[^\"]*\\\")"
+    captures:
+      "1":
+        name: "keyword.preprocessor.load.cs"
+      "2":
+        name: "string.quoted.double.cs"
+  "preprocessor-r":
+    match: "\\b(r)\\b\\s*(\\\"[^\"]*\\\")"
+    captures:
+      "1":
+        name: "keyword.preprocessor.r.cs"
+      "2":
+        name: "string.quoted.double.cs"
   "preprocessor-region":
     match: "\\b(region)\\b\\s*(.*)(?=$)"
     captures:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2474,9 +2474,9 @@ repository:
     - include: '#preprocessor-else-or-endif'
     - include: '#preprocessor-warning-or-error'
     - include: '#preprocessor-region'
+    - include: '#preprocessor-endregion'
     - include: '#preprocessor-load'
     - include: '#preprocessor-r'
-    - include: '#preprocessor-endregion'
     - include: '#preprocessor-line'
     - include: '#preprocessor-pragma-warning'
     - include: '#preprocessor-pragma-checksum'
@@ -2512,16 +2512,24 @@ repository:
       '3': { name: string.unquoted.preprocessor.message.cs }
 
   preprocessor-load:
-    match: \b(load)\b\s*(\"[^"]*\")
-    captures:
-      '1': { name: keyword.preprocessor.load.cs }
-      '2': { name: string.quoted.double.cs }
+    begin: \b(load)\b
+    beginCaptures:
+      '1': { name: keyword.preprocessor.load.cs }  
+    end: (?=$)
+    patterns:
+    - match: \"[^"]*\"
+      captures:
+        '0': { name: string.quoted.double.cs } 
 
   preprocessor-r:
-    match: \b(r)\b\s*(\"[^"]*\")
-    captures:
-      '1': { name: keyword.preprocessor.r.cs }
-      '2': { name: string.quoted.double.cs }
+    begin: \b(r)\b
+    beginCaptures:
+      '1': { name: keyword.preprocessor.r.cs }  
+    end: (?=$)
+    patterns:
+    - match: \"[^"]*\"
+      captures:
+        '0': { name: string.quoted.double.cs } 
 
   preprocessor-region:
     match: \b(region)\b\s*(.*)(?=$)

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2474,6 +2474,8 @@ repository:
     - include: '#preprocessor-else-or-endif'
     - include: '#preprocessor-warning-or-error'
     - include: '#preprocessor-region'
+    - include: '#preprocessor-load'
+    - include: '#preprocessor-r'
     - include: '#preprocessor-endregion'
     - include: '#preprocessor-line'
     - include: '#preprocessor-pragma-warning'
@@ -2508,6 +2510,18 @@ repository:
       '1': { name: keyword.preprocessor.warning.cs }
       '2': { name: keyword.preprocessor.error.cs }
       '3': { name: string.unquoted.preprocessor.message.cs }
+
+  preprocessor-load:
+    match: \b(load)\b\s*(\"[^"]*\")
+    captures:
+      '1': { name: keyword.preprocessor.load.cs }
+      '2': { name: string.quoted.double.cs }
+
+  preprocessor-r:
+    match: \b(r)\b\s*(\"[^"]*\")
+    captures:
+      '1': { name: keyword.preprocessor.r.cs }
+      '2': { name: string.quoted.double.cs }
 
   preprocessor-region:
     match: \b(region)\b\s*(.*)(?=$)

--- a/test/preprocessor.tests.ts
+++ b/test/preprocessor.tests.ts
@@ -672,5 +672,27 @@ public ActionResult Register()
                 Token.Keywords.Preprocessor.EndIf,
             ]);
         });
+
+        it(`#load "foo.csx"`, () => {
+            const input = `#load "foo.csx"`;
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.Hash,
+                Token.Keywords.Preprocessor.Load,
+                Token.Literals.String(`"foo.csx"`)
+            ]);
+        });
+
+        it(`#r "System.Net.dll"`, () => {
+            const input = `#r "System.Net.dll"`;
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.Hash,
+                Token.Keywords.Preprocessor.R,
+                Token.Literals.String(`"System.Net.dll"`)
+            ]);
+        });
     });
 });

--- a/test/preprocessor.tests.ts
+++ b/test/preprocessor.tests.ts
@@ -673,6 +673,16 @@ public ActionResult Register()
             ]);
         });
 
+        it("#load", () => {
+            const input = "#load";
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.Hash,
+                Token.Keywords.Preprocessor.Load
+            ]);
+        });
+
         it(`#load "foo.csx"`, () => {
             const input = `#load "foo.csx"`;
             const tokens = tokenize(input);
@@ -681,6 +691,16 @@ public ActionResult Register()
                 Token.Punctuation.Hash,
                 Token.Keywords.Preprocessor.Load,
                 Token.Literals.String(`"foo.csx"`)
+            ]);
+        });
+
+        it("#r", () => {
+            const input = "#r";
+            const tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Punctuation.Hash,
+                Token.Keywords.Preprocessor.R
             ]);
         });
 

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -260,6 +260,8 @@ export namespace Token {
             export const Restore = createToken('restore', 'keyword.preprocessor.restore.cs');
             export const Undef = createToken('undef', 'keyword.preprocessor.undef.cs');
             export const Warning = createToken('warning', 'keyword.preprocessor.warning.cs');
+            export const R = createToken('r', 'keyword.preprocessor.r.cs');
+            export const Load = createToken('load', 'keyword.preprocessor.load.cs');
         }
 
         export namespace Queries {


### PR DESCRIPTION
This PR introduces tokenization for `#r "{something}"` and `#load "{something}"`. Both of those are valid directives in C# scripting and they are not colorized at the moment.
I can't assign reviewers in this repo so cc @DustinCampbell  🙂