### PR TITLE
Add support for dynamic keyword type

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6072,7 +6072,7 @@
       <key>type-builtin</key>
       <dict>
         <key>match</key>
-        <string>\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void)\b</string>
+        <string>\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void|dynamic)\b</string>
         <key>captures</key>
         <dict>
           <key>1</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3688,7 +3688,7 @@ repository:
       "6":
         name: "entity.name.variable.tuple-element.cs"
   "type-builtin":
-    match: "\\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void)\\b"
+    match: "\\b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void|dynamic)\\b"
     captures:
       "1":
         name: "keyword.type.cs"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2426,7 +2426,7 @@ repository:
       '6': { name: entity.name.variable.tuple-element.cs }
 
   type-builtin:
-    match: \b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void)\b
+    match: \b(bool|byte|char|decimal|double|float|int|long|object|sbyte|short|string|uint|ulong|ushort|void|dynamic)\b
     captures:
       '1': { name: keyword.type.cs }
 

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -417,6 +417,7 @@ export namespace Token {
         export const ULong = createToken('ulong', 'keyword.type.cs');
         export const UShort = createToken('ushort', 'keyword.type.cs');
         export const Void = createToken('void', 'keyword.type.cs');
+        export const Dynamic = createToken('dynamic', 'keyword.type.cs');
     }
 
     export namespace Punctuation {


### PR DESCRIPTION
Looks like adding it as as a built in type work for all the use cases I could think of.
I also didn't add any tests, because there are no tests for other built in types.
Resolves #26.