### PR TITLE
Fix multiplication in parameters not being highlighted correctly

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -897,7 +897,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -1446,7 +1445,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -1517,7 +1515,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -1601,7 +1598,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -1685,7 +1681,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -1899,7 +1894,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -2122,7 +2116,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -2193,7 +2186,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -2951,7 +2943,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -3153,7 +3144,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -3424,7 +3414,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -3500,7 +3489,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -3742,7 +3730,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -3791,7 +3778,6 @@
         (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
-      (?:\s*\*\s*)* # pointer suffix?
       (?:\s*\?\s*)? # nullable suffix?
       (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
     )
@@ -4555,7 +4541,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -4601,7 +4586,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -4641,7 +4625,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -4885,7 +4868,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -4935,7 +4917,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -4976,7 +4957,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -5150,7 +5130,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -5319,7 +5298,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -5480,7 +5458,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -5921,7 +5898,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
@@ -6048,7 +6024,6 @@
       (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\*\s*)* # pointer suffix?
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -578,7 +578,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -903,7 +902,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -956,7 +954,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1018,7 +1015,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1080,7 +1076,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1218,7 +1213,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -1359,7 +1353,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -1411,7 +1404,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -1810,7 +1802,6 @@ repository:
                       (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
                       (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                     )
-                    (?:\\s*\\*\\s*)* # pointer suffix?
                     (?:\\s*\\?\\s*)? # nullable suffix?
                     (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
                   )
@@ -1932,7 +1923,6 @@ repository:
                     (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
                     (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                   )
-                  (?:\\s*\\*\\s*)* # pointer suffix?
                   (?:\\s*\\?\\s*)? # nullable suffix?
                   (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
                 )
@@ -2087,7 +2077,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -2140,7 +2129,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2295,7 +2283,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -2331,7 +2318,6 @@ repository:
               (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
-            (?:\\s*\\*\\s*)* # pointer suffix?
             (?:\\s*\\?\\s*)? # nullable suffix?
             (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
           )
@@ -2737,7 +2723,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2770,7 +2755,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2800,7 +2784,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2953,7 +2936,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -2990,7 +2972,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3021,7 +3002,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3128,7 +3108,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3227,7 +3206,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3333,7 +3311,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3593,7 +3570,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
@@ -3674,7 +3650,6 @@ repository:
             (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\*\\s*)* # pointer suffix?
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -278,7 +278,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -463,7 +462,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -505,7 +503,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -552,7 +549,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -600,7 +596,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -688,7 +683,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -778,7 +772,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -820,7 +813,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1079,7 +1071,6 @@ repository:
                   (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
                   (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
                 )
-                (?:\s*\*\s*)* # pointer suffix?
                 (?:\s*\?\s*)? # nullable suffix?
                 (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
               )
@@ -1162,7 +1153,6 @@ repository:
                 (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
                 (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
               )
-              (?:\s*\*\s*)* # pointer suffix?
               (?:\s*\?\s*)? # nullable suffix?
               (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
             )
@@ -1265,7 +1255,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -1307,7 +1296,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1412,7 +1400,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -1447,7 +1434,6 @@ repository:
               (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
-            (?:\s*\*\s*)* # pointer suffix?
             (?:\s*\?\s*)? # nullable suffix?
             (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
           )
@@ -1735,7 +1721,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1767,7 +1752,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1793,7 +1777,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1909,7 +1892,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1939,7 +1921,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -1966,7 +1947,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -2037,7 +2017,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -2109,7 +2088,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -2182,7 +2160,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -2351,7 +2328,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
@@ -2410,7 +2386,6 @@ repository:
             (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\*\s*)* # pointer suffix?
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -10,6 +10,32 @@ describe("Grammar", () => {
     before(() => should());
 
     describe("Expressions", () => {
+        describe("Object creation", () => {
+            it("with argument multiplication (issue #82)", () => {
+                const input = Input.InMethod(`
+var newPoint = new Vector(point.x * z, 0);`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Var,
+                    Token.Identifiers.LocalName("newPoint"),
+                    Token.Operators.Assignment,
+                    Token.Keywords.New,
+                    Token.Type("Vector"),
+                    Token.Punctuation.OpenParen,
+                    Token.Variables.Object("point"),
+                    Token.Punctuation.Accessor,
+                    Token.Variables.Property("x"),
+                    Token.Operators.Arithmetic.Multiplication,
+                    Token.Variables.ReadWrite("z"),
+                    Token.Punctuation.Comma,
+                    Token.Literals.Numeric.Decimal("0"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+        });
+
         describe("Anonymous Methods", () => {
             it("lambda expression with no parameters (assignment)", () => {
                 const input = Input.InMethod(`Action a = () => { };`);
@@ -824,7 +850,7 @@ public void Method2()
                     Token.Punctuation.OpenParen,
                     Token.Punctuation.CloseParen,
                     Token.Punctuation.OpenBrace,
-                    
+
                     // app.Command()
                     Token.Variables.Object("app"),
                     Token.Punctuation.Accessor,
@@ -874,7 +900,7 @@ var outObjectsToKeep = allOutObjects.Where(outObject => outObject.ShouldKeep);`)
                     Token.Variables.Property("ShouldKeep"),
                     Token.Punctuation.CloseParen,
                     Token.Punctuation.Semicolon,
-                    
+
                     // var outObjectsToKeep = allOutObjects.Where(outObject => outObject.ShouldKeep);;
                     Token.Keywords.Var,
                     Token.Identifiers.LocalName("outObjectsToKeep"),
@@ -2301,6 +2327,21 @@ long total = (data["bonusGame"]["win"].AsLong) * data["bonusGame"]["betMult"].As
                 ]);
             });
 
+            it("multiplicated parameters (issue #99)", () => {
+                const input = Input.InMethod(`Multiply(n1 * n2);`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Identifiers.MethodName("Multiply"),
+                    Token.Punctuation.OpenParen,
+                    Token.Variables.ReadWrite("n1"),
+                    Token.Operators.Arithmetic.Multiplication,
+                    Token.Variables.ReadWrite("n2"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+
             it("chained method calls", () => {
                 const input = Input.InMethod(`M1().M2();`);
                 const tokens = tokenize(input);
@@ -3212,7 +3253,7 @@ private static readonly Parser<Node> NodeParser =
                     Token.Punctuation.Semicolon
                 ]);
             });
-            
+
             it("query join with anonymous type (issue #89)", () => {
                 const input = Input.InMethod(`
 var q = from x in list1

--- a/test/statements.tests.ts
+++ b/test/statements.tests.ts
@@ -142,6 +142,35 @@ for (int i = 0; i < 42; i++)
                     Token.Punctuation.CloseBrace,
                 ]);
             });
+
+            it("for loop with argument multiplication (issue #99)", () => {
+                const input = Input.InMethod(`
+    for (int i = 0; i < n1 * n2; i++)
+    {
+    }`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Control.For,
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.LocalName("i"),
+                    Token.Operators.Assignment,
+                    Token.Literals.Numeric.Decimal("0"),
+                    Token.Punctuation.Semicolon,
+                    Token.Variables.ReadWrite("i"),
+                    Token.Operators.Relational.LessThan,
+                    Token.Variables.ReadWrite("n1"),
+                    Token.Operators.Arithmetic.Multiplication,
+                    Token.Variables.ReadWrite("n2"),
+                    Token.Punctuation.Semicolon,
+                    Token.Variables.ReadWrite("i"),
+                    Token.Operators.Increment,
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace,
+                ]);
+            });
         });
 
         describe("ForEach", () => {


### PR DESCRIPTION
Didn't want to introduce additional complexity here, so I just removed all `pointer suffix` expressions, because even with them pointer suffixes are styled as `keyword.operator.arithmetic.cs` or are breaking syntax highlight around them. I'm also finishing verbatim identifier support #25, so it might be used as an example for future pointer support as their have similarities in character "positioning".

And I think we can all agree that multiplication is used way more often than pointers in c#, so it's better to have correct syntax highlight for them. Especially knowing that currently pointers aren't styled differently.

Fixes #82, #99.