### PR TITLE
Highlight `stackalloc` keyword

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -4950,7 +4950,7 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-\b(new)\b\s*
+\b(new|stackalloc)\b\s*
 (?&lt;type-name&gt;
   (?:
     (?:

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2992,7 +2992,7 @@ repository:
   "array-creation-expression":
     begin: '''
       (?x)
-      \\b(new)\\b\\s*
+      \\b(new|stackalloc)\\b\\s*
       (?<type-name>
         (?:
           (?:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -232,7 +232,7 @@ repository:
 
   storage-modifier:
     name: 'storage.modifier.cs'
-    match: (?<!\.)\b(new|stackalloc|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref)\b
+    match: (?<!\.)\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref)\b
 
   class-declaration:
     begin: (?=\bclass\b)

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -232,7 +232,7 @@ repository:
 
   storage-modifier:
     name: 'storage.modifier.cs'
-    match: (?<!\.)\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref)\b
+    match: (?<!\.)\b(new|stackalloc|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref)\b
 
   class-declaration:
     begin: (?=\bclass\b)
@@ -1936,7 +1936,7 @@ repository:
   array-creation-expression:
     begin: |-
       (?x)
-      \b(new)\b\s*
+      \b(new|stackalloc)\b\s*
       (?<type-name>
         (?:
           (?:

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -12,8 +12,7 @@ describe("Grammar", () => {
     describe("Expressions", () => {
         describe("Object creation", () => {
             it("with argument multiplication (issue #82)", () => {
-                const input = Input.InMethod(`
-var newPoint = new Vector(point.x * z, 0);`);
+                const input = Input.InMethod(`var newPoint = new Vector(point.x * z, 0);`);
                 const tokens = tokenize(input);
 
                 tokens.should.deep.equal([
@@ -31,6 +30,40 @@ var newPoint = new Vector(point.x * z, 0);`);
                     Token.Punctuation.Comma,
                     Token.Literals.Numeric.Decimal("0"),
                     Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+
+            it("with stackalloc keyword and byte array", () => {
+                const input = Input.InMethod(`var bytes = stackalloc byte[10];`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Var,
+                    Token.Identifiers.LocalName("bytes"),
+                    Token.Operators.Assignment,
+                    Token.Keywords.Stackalloc,
+                    Token.PrimitiveType.Byte,
+                    Token.Punctuation.OpenBracket,
+                    Token.Literals.Numeric.Decimal("10"),
+                    Token.Punctuation.CloseBracket,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+
+            it("with stackalloc keyword and int array", () => {
+                const input = Input.InMethod(`var ints = stackalloc int[42];`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Var,
+                    Token.Identifiers.LocalName("ints"),
+                    Token.Operators.Assignment,
+                    Token.Keywords.Stackalloc,
+                    Token.PrimitiveType.Int,
+                    Token.Punctuation.OpenBracket,
+                    Token.Literals.Numeric.Decimal("42"),
+                    Token.Punctuation.CloseBracket,
                     Token.Punctuation.Semicolon
                 ]);
             });

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -303,6 +303,7 @@ export namespace Token {
         export const NameOf = createToken('nameof', 'keyword.other.nameof.cs');
         export const Namespace = createToken('namespace', 'keyword.other.namespace.cs');
         export const New = createToken('new', 'keyword.other.new.cs');
+        export const Stackalloc = createToken('stackalloc', 'keyword.other.new.cs');
         export const Operator = createToken('operator', 'keyword.other.operator-decl.cs');
         export const Remove = createToken('remove', 'keyword.other.remove.cs');
         export const Set = createToken('set', 'keyword.other.set.cs');


### PR DESCRIPTION
Hi. You know, there is a keyword in C# language named `stackalloc`. This keyword doesn't get highlighted properly in Visual Studio Code editor and <a href="https://github.com/dotnet/corefx/blob/5f2e78f0bd7d2bee1b6e332edc176e87283bdaed/src/Common/src/CoreLib/System/Numerics/Vector.cs#L1602">on Github</a>. Both services highly depend on `csharp-tmLanguage`, so let's improve them. This PR brings support for `stackalloc` keyword highlighting! Thanks @nestquik for reviewing this.