### PR TITLE
Implement character escape sequences for string/char fixes #28

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -4194,9 +4194,16 @@
         <array>
           <dict>
             <key>include</key>
-            <string>#string-character-escape</string>
+            <string>#char-character-escape</string>
           </dict>
         </array>
+      </dict>
+      <key>char-character-escape</key>
+      <dict>
+        <key>name</key>
+        <string>constant.character.escape.cs</string>
+        <key>match</key>
+        <string>\\(['"\\0abfnrtv]|x[0-9a-fA-F]{1,4}|u[0-9a-fA-F]{4})</string>
       </dict>
       <key>string-literal</key>
       <dict>
@@ -4240,7 +4247,7 @@
         <key>name</key>
         <string>constant.character.escape.cs</string>
         <key>match</key>
-        <string>\\.</string>
+        <string>\\(['"\\0abfnrtv]|x[0-9a-fA-F]{1,4}|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4})</string>
       </dict>
       <key>verbatim-string-literal</key>
       <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2534,9 +2534,12 @@ repository:
         name: "invalid.illegal.newline.cs"
     patterns: [
       {
-        include: "#string-character-escape"
+        include: "#char-character-escape"
       }
     ]
+  "char-character-escape":
+    name: "constant.character.escape.cs"
+    match: "\\\\(['\"\\\\0abfnrtv]|x[0-9a-fA-F]{1,4}|u[0-9a-fA-F]{4})"
   "string-literal":
     name: "string.quoted.double.cs"
     begin: "(?<!@)\""
@@ -2556,7 +2559,7 @@ repository:
     ]
   "string-character-escape":
     name: "constant.character.escape.cs"
-    match: "\\\\."
+    match: "\\\\(['\"\\\\0abfnrtv]|x[0-9a-fA-F]{1,4}|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4})"
   "verbatim-string-literal":
     name: "string.quoted.double.cs"
     begin: "@\""

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1585,7 +1585,11 @@ repository:
       '1': { name: punctuation.definition.char.end.cs }
       '2': { name: invalid.illegal.newline.cs }
     patterns:
-    - include: '#string-character-escape'
+    - include: '#char-character-escape'
+
+  char-character-escape:
+    name: constant.character.escape.cs
+    match: \\(['"\\0abfnrtv]|x[0-9a-fA-F]{1,4}|u[0-9a-fA-F]{4})
 
   string-literal:
     name: string.quoted.double.cs
@@ -1601,7 +1605,7 @@ repository:
 
   string-character-escape:
     name: constant.character.escape.cs
-    match: \\.
+    match: \\(['"\\0abfnrtv]|x[0-9a-fA-F]{1,4}|U[0-9a-fA-F]{8}|u[0-9a-fA-F]{4})
 
   verbatim-string-literal:
     name: string.quoted.double.cs

--- a/test/literals.tests.ts
+++ b/test/literals.tests.ts
@@ -77,6 +77,76 @@ describe("Grammar", () => {
                     Token.Punctuation.Char.End,
                     Token.Punctuation.Semicolon]);
             });
+
+            it("escaped character escape \\t", () => {
+                const input = Input.InClass(`char x = '\\t';`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.Char,
+                    Token.Identifiers.FieldName("x"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.Char.Begin,
+                    Token.Literals.CharacterEscape("\\t"),
+                    Token.Punctuation.Char.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\n", () => {
+                const input = Input.InClass(`char x = '\\n';`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.Char,
+                    Token.Identifiers.FieldName("x"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.Char.Begin,
+                    Token.Literals.CharacterEscape("\\n"),
+                    Token.Punctuation.Char.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\x1f2d", () => {
+                const input = Input.InClass(`char x = '\\x1f2d';`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.Char,
+                    Token.Identifiers.FieldName("x"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.Char.Begin,
+                    Token.Literals.CharacterEscape("\\x1f2d"),
+                    Token.Punctuation.Char.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\x1", () => {
+                const input = Input.InClass(`char x = '\\x1';`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.Char,
+                    Token.Identifiers.FieldName("x"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.Char.Begin,
+                    Token.Literals.CharacterEscape("\\x1"),
+                    Token.Punctuation.Char.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\ude12", () => {
+                const input = Input.InClass(`char x = '\\ude12';`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.Char,
+                    Token.Identifiers.FieldName("x"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.Char.Begin,
+                    Token.Literals.CharacterEscape("\\ude12"),
+                    Token.Punctuation.Char.End,
+                    Token.Punctuation.Semicolon]);
+            });
         });
 
         describe("Numbers", () => {
@@ -157,6 +227,102 @@ describe("Grammar", () => {
                     Token.Literals.CharacterEscape("\\\""),
                     Token.Literals.String("world!"),
                     Token.Literals.CharacterEscape("\\\""),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+            
+            it("escaped character escape \\t", () => {
+                const input = Input.InClass(`string test = "hello\\tworld!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\t"),
+                    Token.Literals.String("world!"),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\n", () => {
+                const input = Input.InClass(`string test = "hello\\nworld!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\n"),
+                    Token.Literals.String("world!"),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\x1f2d", () => {
+                const input = Input.InClass(`string test = "hello\\x1f2da world!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\x1f2d"),
+                    Token.Literals.String("a world!"),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\x1", () => {
+                const input = Input.InClass(`string test = "hello\\x1 a world!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\x1"),
+                    Token.Literals.String(" a world!"),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\ude12", () => {
+                const input = Input.InClass(`string test = "hello\\ude12a world!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\ude12"),
+                    Token.Literals.String("a world!"),
+                    Token.Punctuation.String.End,
+                    Token.Punctuation.Semicolon]);
+            });
+
+            it("escaped character escape \\U0001de12", () => {
+                const input = Input.InClass(`string test = "hello\\U0001de12a world!";`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.FieldName("test"),
+                    Token.Operators.Assignment,
+                    Token.Punctuation.String.Begin,
+                    Token.Literals.String("hello"),
+                    Token.Literals.CharacterEscape("\\U0001de12"),
+                    Token.Literals.String("a world!"),
                     Token.Punctuation.String.End,
                     Token.Punctuation.Semicolon]);
             });


### PR DESCRIPTION
Implements character escapes for strings and chars as defined by C#:

- `\0 \a \b \f \n \r \t \v` single-character sequences for strings and chars
- `\uxxxx` unicode sequence for strings and chars (X=hex digit case-insensitive)
- `\Uxxxxxxxx` unicode sequence for strings

This doesn't implement the \u and \U for identifiers - should that be covered in this PR or a separate issue/PR?

