### PR TITLE
Allow unicode esc in method, property, class & namespace declarations (don't merge yet)

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -741,7 +741,7 @@
             <key>name</key>
             <string>entity.name.type.namespace.cs</string>
             <key>match</key>
-            <string>@?[_[:alpha:]][_[:alnum:]]*</string>
+            <string>@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*</string>
           </dict>
           <dict>
             <key>include</key>
@@ -805,7 +805,7 @@
             <key>begin</key>
             <string>(?x)
 \b(class)\b\s+
-(@?[_[:alpha:]][_[:alnum:]]*)\s*</string>
+(@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -1511,7 +1511,7 @@
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref return
       (?:
-        (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+        (?:(?&lt;identifier&gt;@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*\:\:\s*)? # alias-qualification
         (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
           (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
@@ -1890,7 +1890,7 @@
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref return
       (?:
-        (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+        (?:(?&lt;identifier&gt;@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*\:\:\s*)? # alias-qualification
         (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
           (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -479,7 +479,7 @@ repository:
       }
       {
         name: "entity.name.type.namespace.cs"
-        match: "@?[_[:alpha:]][_[:alnum:]]*"
+        match: "@?(?:[_[:alpha:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{4})*"
       }
       {
         include: "#punctuation-accessor"
@@ -517,7 +517,7 @@ repository:
         begin: '''
           (?x)
           \\b(class)\\b\\s+
-          (@?[_[:alpha:]][_[:alnum:]]*)\\s*
+          (@?(?:[_[:alpha:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{4})*)\\s*
         '''
         beginCaptures:
           "1":
@@ -950,7 +950,7 @@ repository:
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?(?:[_[:alpha:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{4})*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<name-and-type-args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
@@ -1209,7 +1209,7 @@ repository:
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+              (?:(?<identifier>@?(?:[_[:alpha:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\\\u[0-9a-fA-F]{4}|\\\\U[0-9a-fA-F]{4})*)\\s*\\:\\:\\s*)? # alias-qualification
               (?<name-and-type-args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
                 (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -217,7 +217,7 @@ repository:
     patterns:
     - include: '#comment'
     - name: entity.name.type.namespace.cs
-      match: '@?[_[:alpha:]][_[:alnum:]]*'
+      match: '@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*'
     - include: '#punctuation-accessor'
     - begin: \{
       beginCaptures:
@@ -241,7 +241,7 @@ repository:
     - begin: |-
         (?x)
         \b(class)\b\s+
-        (@?[_[:alpha:]][_[:alnum:]]*)\s*
+        (@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*
       beginCaptures:
         '1': { name: keyword.other.class.cs }
         '2': { name: entity.name.type.class.cs }
@@ -499,7 +499,7 @@ repository:
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+              (?:(?<identifier>@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*\:\:\s*)? # alias-qualification
               (?<name-and-type-args> # identifier + type arguments (if any)
                 \g<identifier>\s*
                 (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
@@ -679,7 +679,7 @@ repository:
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref return
             (?:
-              (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+              (?:(?<identifier>@?(?:[_[:alpha:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[_[:alnum:]]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{4})*)\s*\:\:\s*)? # alias-qualification
               (?<name-and-type-args> # identifier + type arguments (if any)
                 \g<identifier>\s*
                 (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?

--- a/test/class.tests.ts
+++ b/test/class.tests.ts
@@ -91,6 +91,30 @@ public    abstract class PublicAbstractClass { }
                 Token.Punctuation.CloseBrace]);
         });
 
+        it("\\uxxxx unicode sequence in identifier", () => {
+
+            const input = `class \\u1234yCl\\u123fss { }`;
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Class,
+                Token.Identifiers.ClassName("\\u1234yCl\\u123fss"),
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
+        it("\\Uxxxxxxxx unicode sequence in identifier", () => {
+
+            const input = `class \\U00001234yCl\\U0000123fss { }`;
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Class,
+                Token.Identifiers.ClassName("\\U00001234yCl\\U0000123fss"),
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
         it("generics in identifier", () => {
 
             const input = Input.InNamespace(`class Dictionary<TKey, TValue> { }`);

--- a/test/method.tests.ts
+++ b/test/method.tests.ts
@@ -23,6 +23,32 @@ describe("Grammar", () => {
                 Token.Punctuation.CloseBrace]);
         });
 
+        it("\\uxxxx unicode sequence in identifier", () => {
+            const input = Input.InClass(`void \\u004De\\u0074hod() { }`);
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.PrimitiveType.Void,
+                Token.Identifiers.MethodName("\\u004De\\u0074hod"),
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
+        it("\\Uxxxxxxxx unicode sequence in identifier", () => {
+            const input = Input.InClass(`void \\U0000004De\\U00000074hod() { }`);
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.PrimitiveType.Void,
+                Token.Identifiers.MethodName("\\U0000004De\\U00000074hod"),
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
         it("declaration with two parameters", () => {
             const input = Input.InClass(`
 int Add(int x, int y)

--- a/test/namespace.tests.ts
+++ b/test/namespace.tests.ts
@@ -42,6 +42,40 @@ namespace Test.Namespace
                 Token.Punctuation.CloseBrace]);
         });
 
+        it("has a namespace keyword and a \\uxxxx unicode sequence", () => {
+
+            const input = `
+namespace \\u1234Test.Na\\u123fmespace
+{
+}`;
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Namespace,
+                Token.Identifiers.NamespaceName("\\u1234Test"),
+                Token.Punctuation.Accessor,
+                Token.Identifiers.NamespaceName("Na\\u123fmespace"),
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
+        it("has a namespace keyword and a \\Uxxxxxxxx unicode sequence", () => {
+
+            const input = `
+namespace \\U00001234Test.Na\\U0000123fmespace
+{
+}`;
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Namespace,
+                Token.Identifiers.NamespaceName("\\U00001234Test"),
+                Token.Punctuation.Accessor,
+                Token.Identifiers.NamespaceName("Na\\U0000123fmespace"),
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace]);
+        });
+
         it("can be nested", () => {
 
             const input = `

--- a/test/property.tests.ts
+++ b/test/property.tests.ts
@@ -114,6 +114,36 @@ public IBooom Property
                 Token.Punctuation.CloseBrace]);
         });
 
+        it("\\uxxxx unicode sequence in identifier", () => {
+            const input = Input.InClass(`int \\u0050rope\\u0072ty { get; set; }`);
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.PrimitiveType.Int,
+                Token.Identifiers.PropertyName("\\u0050rope\\u0072ty"),
+                Token.Punctuation.OpenBrace,
+                Token.Keywords.Get,
+                Token.Punctuation.Semicolon,
+                Token.Keywords.Set,
+                Token.Punctuation.Semicolon,
+                Token.Punctuation.CloseBrace]);
+        });
+
+        it("\\Uxxxxxxxx unicode sequence in identifier", () => {
+            const input = Input.InClass(`int \\U00000050rope\\U00000072ty { get; set; }`);
+            let tokens = tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.PrimitiveType.Int,
+                Token.Identifiers.PropertyName("\\U00000050rope\\U00000072ty"),
+                Token.Punctuation.OpenBrace,
+                Token.Keywords.Get,
+                Token.Punctuation.Semicolon,
+                Token.Keywords.Set,
+                Token.Punctuation.Semicolon,
+                Token.Punctuation.CloseBrace]);
+        });
+
         it("auto-property", () => {
             const input = Input.InClass(`
 public IBooom Property


### PR DESCRIPTION
Allows `\uxxxx` and `\Uxxxxxxxx` unicode escape sequences in identifiers (related to #28).  So far this PR supports them in 

- namespace declaration names
- class declaration names
- property declaration names
- method declaration names

e.g. The following Identifiers:

```csharp
namespace Identifer.Identifier {
 class Identifier {
   int Identifier { get; set; }
   void Identifier() { }
}
```

If this looks good I can continue adding the rest of the possibilities before this PR is merged.