### PR TITLE
Fix issue with async lambda with single parameter assigned to dotted name

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -3424,6 +3424,7 @@
   )
 )\s+
 (\g&lt;identifier&gt;)\s*
+(?!=&gt;)
 (?=,|;|=|\))</string>
         <key>beginCaptures</key>
         <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2087,6 +2087,7 @@ repository:
         )
       )\\s+
       (\\g<identifier>)\\s*
+      (?!=>)
       (?=,|;|=|\\))
     '''
     beginCaptures:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1265,6 +1265,7 @@ repository:
         )
       )\s+
       (\g<identifier>)\s*
+      (?!=>)
       (?=,|;|=|\))
     beginCaptures:
       '1': { name: storage.modifier.cs }

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -376,6 +376,27 @@ describe("Grammar", () => {
                 ]);
             });
 
+            it("async lambda assigned to dotted name (issue #142)", () => {
+                const input = Input.InMethod(`Something.listener = async args => { return true; };`);
+                const tokens = tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Variables.Object("Something"),
+                    Token.Punctuation.Accessor,
+                    Token.Variables.Property("listener"),
+                    Token.Operators.Assignment,
+                    Token.Keywords.Modifiers.Async,
+                    Token.Identifiers.ParameterName("args"),
+                    Token.Operators.Arrow,
+                    Token.Punctuation.OpenBrace,
+                    Token.Keywords.Control.Return,
+                    Token.Literals.Boolean.True,
+                    Token.Punctuation.Semicolon,
+                    Token.Punctuation.CloseBrace,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+            
             it("anonymous method with no parameter list (assignment)", () => {
                 const input = Input.InMethod(`Action a = delegate { };`);
                 const tokens = tokenize(input);


### PR DESCRIPTION
Fixes #142 

Consider the following code:

```C#
Something.listener = async args => { return true; };
```

When a dotted name is followed by an assignment to an async lambda, the lambda is incorrectly matched as a local variable declaration. Essentially, "async" is matched as a local variable type name, "args" is matched as the local variable name and the following "=" is matched as an assignment to the local variable. The fix is to ensure that we check for "=>" and don't match a local variable declaration in that case. This allows the normal lambda expression rule to win.