### PR TITLE
Make grammar PCRE compatible

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -885,16 +885,16 @@
         <key>begin</key>
         <string>(?x)
 (?:\b(delegate)\b)\s+
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:ref\s+(?:readonly\s+)?)?   # ref return
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -1434,15 +1434,15 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -1506,17 +1506,17 @@
 # or other declarations as properties.
 (?![[:word:][:space:]]*\b(?:class|interface|struct|enum|event)\b)
 
-(?&lt;return-type&gt;
-  (?&lt;type-name&gt;
+(?&lt;return_type&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref return
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -1524,8 +1524,8 @@
     )
   )\s+
 )
-(?&lt;interface-name&gt;\g&lt;type-name&gt;\s*\.\s*)?
-(?&lt;property-name&gt;\g&lt;identifier&gt;)\s*
+(?&lt;interface_name&gt;\g&lt;type_name&gt;\s*\.\s*)?
+(?&lt;property_name&gt;\g&lt;identifier&gt;)\s*
 (?=\{|=&gt;|$)</string>
         <key>beginCaptures</key>
         <dict>
@@ -1589,17 +1589,17 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;return-type&gt;
-  (?&lt;type-name&gt;
+(?&lt;return_type&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref return
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -1607,8 +1607,8 @@
     )
   )\s+
 )
-(?&lt;interface-name&gt;\g&lt;type-name&gt;\s*\.\s*)?
-(?&lt;indexer-name&gt;this)\s*
+(?&lt;interface_name&gt;\g&lt;type_name&gt;\s*\.\s*)?
+(?&lt;indexer_name&gt;this)\s*
 (?=\[)</string>
         <key>beginCaptures</key>
         <dict>
@@ -1673,16 +1673,16 @@
         <key>begin</key>
         <string>(?x)
 \b(event)\b\s*
-(?&lt;return-type&gt;
-  (?&lt;type-name&gt;
+(?&lt;return_type&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -1690,8 +1690,8 @@
     )
   )\s+
 )
-(?&lt;interface-name&gt;\g&lt;type-name&gt;\s*\.\s*)?
-(?&lt;event-names&gt;\g&lt;identifier&gt;(?:\s*,\s*\g&lt;identifier&gt;)*)\s*
+(?&lt;interface_name&gt;\g&lt;type_name&gt;\s*\.\s*)?
+(?&lt;event_names&gt;\g&lt;identifier&gt;(?:\s*,\s*\g&lt;identifier&gt;)*)\s*
 (?=\{|;|$)</string>
         <key>beginCaptures</key>
         <dict>
@@ -1885,17 +1885,17 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;return-type&gt;
-  (?&lt;type-name&gt;
+(?&lt;return_type&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref return
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -1903,7 +1903,7 @@
     )
   )\s+
 )
-(?&lt;interface-name&gt;\g&lt;type-name&gt;\s*\.\s*)?
+(?&lt;interface_name&gt;\g&lt;type_name&gt;\s*\.\s*)?
 (\g&lt;identifier&gt;)\s*
 (&lt;([^&lt;&gt;]+)&gt;)?\s*
 (?=\()</string>
@@ -2108,23 +2108,23 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:ref\s+(?:readonly\s+)?)?   # ref return
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
 )\s*
-(?&lt;operator-keyword&gt;(?:\b(?:operator)))\s*
+(?&lt;operator_keyword&gt;(?:\b(?:operator)))\s*
 (?&lt;operator&gt;(?:\+|-|\*|/|%|&amp;|\||\^|\&lt;\&lt;|\&gt;\&gt;|==|!=|\&gt;|\&lt;|\&gt;=|\&lt;=|!|~|\+\+|--|true|false))\s*
 (?=\()</string>
         <key>beginCaptures</key>
@@ -2176,18 +2176,18 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;explicit-or-implicit-keyword&gt;(?:\b(?:explicit|implicit)))\s*
-(?&lt;operator-keyword&gt;(?:\b(?:operator)))\s*
-(?&lt;type-name&gt;
+(?&lt;explicit_or_implicit_keyword&gt;(?:\b(?:explicit|implicit)))\s*
+(?&lt;operator_keyword&gt;(?:\b(?:operator)))\s*
+(?&lt;type_name&gt;
   (?:
     (?:ref\s+(?:readonly\s+)?)?   # ref return
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -2936,15 +2936,15 @@
                 <string>(?x)
 (?:
   (\bvar\b)|
-  (?&lt;type-name&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -3137,15 +3137,15 @@
               <dict>
                 <key>match</key>
                 <string>(?x)
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -3406,16 +3406,16 @@
         <string>(?x)
 (?:
   (?:(\bref)\s+(?:(\breadonly)\s+)?)?(\bvar\b)| # ref local
-  (?&lt;type-name&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:ref\s+(?:readonly\s+)?)?   # ref local
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -3487,16 +3487,16 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(?&lt;const-keyword&gt;\b(?:const)\b)\s*
-(?&lt;type-name&gt;
+(?&lt;const_keyword&gt;\b(?:const)\b)\s*
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -3729,15 +3729,15 @@
         <string>(?x) # e.g. int x OR var x
 (?:
   \b(var)\b|
-  (?&lt;type-name&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -3777,15 +3777,15 @@
         <string>(?x) # e.g. int x OR var x
 (?:
   \b(var)\b|
-  (?&lt;type-name&gt;
+  (?&lt;type_name&gt;
     (?:
       (?:
         (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-        (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+        (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
           \g&lt;identifier&gt;\s*
-          (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+          (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
         )
-        (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+        (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
         (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
       )
       (?:\s*\?\s*)? # nullable suffix?
@@ -4547,15 +4547,15 @@
         <key>match</key>
         <string>(?x)
 (\()\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -4592,15 +4592,15 @@
         <key>match</key>
         <string>(?x)
 (?&lt;!\.)\b(as)\b\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -4631,15 +4631,15 @@
         <key>match</key>
         <string>(?x)
 (?&lt;!\.)\b(is)\b\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -4690,7 +4690,7 @@
 (?:(\?)\s*)?                                     # preceding null-conditional operator?
 (?:(\.)\s*)?                                     # preceding dot?
 (@?[_[:alpha:]][_[:alnum:]]*)\s*                   # method name
-(?&lt;type-args&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?\s* # type arguments
+(?&lt;type_args&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?\s* # type arguments
 (?=\()                                           # open paren of argument list</string>
         <key>beginCaptures</key>
         <dict>
@@ -4807,7 +4807,7 @@
             <string>(?x)
 (\.)?\s*
 (@?[_[:alpha:]][_[:alnum:]]*)
-(?&lt;type-params&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type-params&gt;)+&gt;\s*)
+(?&lt;type_params&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type_params&gt;)+&gt;\s*)
 (?=
   (\s*\?)?
   \s*\.\s*@?[_[:alpha:]][_[:alnum:]]*
@@ -4874,15 +4874,15 @@
         <key>begin</key>
         <string>(?x)
 (new)\s+
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -4923,15 +4923,15 @@
         <key>match</key>
         <string>(?x)
 (new)\s+
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -4963,15 +4963,15 @@
         <key>begin</key>
         <string>(?x)
 \b(new|stackalloc)\b\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -5135,16 +5135,16 @@
         <key>match</key>
         <string>(?x)
 (?:(?:\b(ref|params|out|in|this)\b)\s+)?
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:ref\s+)?   # ref return
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -5304,15 +5304,15 @@
         <key>begin</key>
         <string>(?x)
 \b(from)\b\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -5464,15 +5464,15 @@
         <key>begin</key>
         <string>(?x)
 \b(join)\b\s*
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -5904,15 +5904,15 @@
         <key>match</key>
         <string>(?x)
 (?:\b(ref|out|in)\b)?\s*
-(?:(?&lt;type-name&gt;
+(?:(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
@@ -6041,22 +6041,22 @@
       <dict>
         <key>match</key>
         <string>(?x)
-(?&lt;type-name&gt;
+(?&lt;type_name&gt;
   (?:
     (?:
       (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-      (?&lt;name-and-type-args&gt; # identifier + type arguments (if any)
+      (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
         \g&lt;identifier&gt;\s*
-        (?&lt;type-args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type-args&gt;)+&gt;\s*)?
+        (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
       )
-      (?:\s*\.\s*\g&lt;name-and-type-args&gt;)* | # Are there any more names being dotted into?
+      (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
     (?:\s*\?\s*)? # nullable suffix?
     (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
   )
 )
-(?:(?&lt;tuple-name&gt;\g&lt;identifier&gt;)\b)?</string>
+(?:(?&lt;tuple_name&gt;\g&lt;identifier&gt;)\b)?</string>
         <key>captures</key>
         <dict>
           <key>1</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -566,16 +566,16 @@ repository:
     begin: '''
       (?x)
       (?:\\b(delegate)\\b)\\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -891,15 +891,15 @@ repository:
   "field-declaration":
     begin: '''
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -945,17 +945,17 @@ repository:
       # or other declarations as properties.
       (?![[:word:][:space:]]*\\b(?:class|interface|struct|enum|event)\\b)
       
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -963,8 +963,8 @@ repository:
           )
         )\\s+
       )
-      (?<interface-name>\\g<type-name>\\s*\\.\\s*)?
-      (?<property-name>\\g<identifier>)\\s*
+      (?<interface_name>\\g<type_name>\\s*\\.\\s*)?
+      (?<property_name>\\g<identifier>)\\s*
       (?=\\{|=>|$)
     '''
     beginCaptures:
@@ -1006,17 +1006,17 @@ repository:
   "indexer-declaration":
     begin: '''
       (?x)
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -1024,8 +1024,8 @@ repository:
           )
         )\\s+
       )
-      (?<interface-name>\\g<type-name>\\s*\\.\\s*)?
-      (?<indexer-name>this)\\s*
+      (?<interface_name>\\g<type_name>\\s*\\.\\s*)?
+      (?<indexer_name>this)\\s*
       (?=\\[)
     '''
     beginCaptures:
@@ -1068,16 +1068,16 @@ repository:
     begin: '''
       (?x)
       \\b(event)\\b\\s*
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -1085,8 +1085,8 @@ repository:
           )
         )\\s+
       )
-      (?<interface-name>\\g<type-name>\\s*\\.\\s*)?
-      (?<event-names>\\g<identifier>(?:\\s*,\\s*\\g<identifier>)*)\\s*
+      (?<interface_name>\\g<type_name>\\s*\\.\\s*)?
+      (?<event_names>\\g<identifier>(?:\\s*,\\s*\\g<identifier>)*)\\s*
       (?=\\{|;|$)
     '''
     beginCaptures:
@@ -1204,17 +1204,17 @@ repository:
   "method-declaration":
     begin: '''
       (?x)
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -1222,7 +1222,7 @@ repository:
           )
         )\\s+
       )
-      (?<interface-name>\\g<type-name>\\s*\\.\\s*)?
+      (?<interface_name>\\g<type_name>\\s*\\.\\s*)?
       (\\g<identifier>)\\s*
       (<([^<>]+)>)?\\s*
       (?=\\()
@@ -1345,23 +1345,23 @@ repository:
   "operator-declaration":
     begin: '''
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )\\s*
-      (?<operator-keyword>(?:\\b(?:operator)))\\s*
+      (?<operator_keyword>(?:\\b(?:operator)))\\s*
       (?<operator>(?:\\+|-|\\*|/|%|&|\\||\\^|\\<\\<|\\>\\>|==|!=|\\>|\\<|\\>=|\\<=|!|~|\\+\\+|--|true|false))\\s*
       (?=\\()
     '''
@@ -1394,18 +1394,18 @@ repository:
   "conversion-operator-declaration":
     begin: '''
       (?x)
-      (?<explicit-or-implicit-keyword>(?:\\b(?:explicit|implicit)))\\s*
-      (?<operator-keyword>(?:\\b(?:operator)))\\s*
-      (?<type-name>
+      (?<explicit_or_implicit_keyword>(?:\\b(?:explicit|implicit)))\\s*
+      (?<operator_keyword>(?:\\b(?:operator)))\\s*
+      (?<type_name>
         (?:
           (?:ref\\s+(?:readonly\\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -1795,15 +1795,15 @@ repository:
               (?x)
               (?:
                 (\\bvar\\b)|
-                (?<type-name>
+                (?<type_name>
                   (?:
                     (?:
                       (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-                      (?<name-and-type-args> # identifier + type arguments (if any)
+                      (?<name_and_type_args> # identifier + type arguments (if any)
                         \\g<identifier>\\s*
-                        (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                        (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
                       )
-                      (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+                      (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
                       (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                     )
                     (?:\\s*\\?\\s*)? # nullable suffix?
@@ -1916,15 +1916,15 @@ repository:
           {
             match: '''
               (?x)
-              (?<type-name>
+              (?<type_name>
                 (?:
                   (?:
                     (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-                    (?<name-and-type-args> # identifier + type arguments (if any)
+                    (?<name_and_type_args> # identifier + type arguments (if any)
                       \\g<identifier>\\s*
-                      (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                      (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
                     )
-                    (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+                    (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
                     (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
                   )
                   (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2069,16 +2069,16 @@ repository:
       (?x)
       (?:
         (?:(\\bref)\\s+(?:(\\breadonly)\\s+)?)?(\\bvar\\b)| # ref local
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:ref\\s+(?:readonly\\s+)?)?   # ref local
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2124,16 +2124,16 @@ repository:
   "local-constant-declaration":
     begin: '''
       (?x)
-      (?<const-keyword>\\b(?:const)\\b)\\s*
-      (?<type-name>
+      (?<const_keyword>\\b(?:const)\\b)\\s*
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2279,15 +2279,15 @@ repository:
       (?x) # e.g. int x OR var x
       (?:
         \\b(var)\\b|
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2314,15 +2314,15 @@ repository:
       (?x) # e.g. int x OR var x
       (?:
         \\b(var)\\b|
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \\g<identifier>\\s*
-                (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+                (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
               )
-              (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
             )
             (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2722,15 +2722,15 @@ repository:
     match: '''
       (?x)
       (\\()\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2754,15 +2754,15 @@ repository:
     match: '''
       (?x)
       (?<!\\.)\\b(as)\\b\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2783,15 +2783,15 @@ repository:
     match: '''
       (?x)
       (?<!\\.)\\b(is)\\b\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2821,7 +2821,7 @@ repository:
       (?:(\\?)\\s*)?                                     # preceding null-conditional operator?
       (?:(\\.)\\s*)?                                     # preceding dot?
       (@?[_[:alpha:]][_[:alnum:]]*)\\s*                   # method name
-      (?<type-args>\\s*<([^<>]|\\g<type-args>)+>\\s*)?\\s* # type arguments
+      (?<type_args>\\s*<([^<>]|\\g<type_args>)+>\\s*)?\\s* # type arguments
       (?=\\()                                           # open paren of argument list
     '''
     beginCaptures:
@@ -2890,7 +2890,7 @@ repository:
           (?x)
           (\\.)?\\s*
           (@?[_[:alpha:]][_[:alnum:]]*)
-          (?<type-params>\\s*<([^<>]|\\g<type-params>)+>\\s*)
+          (?<type_params>\\s*<([^<>]|\\g<type_params>)+>\\s*)
           (?=
             (\\s*\\?)?
             \\s*\\.\\s*@?[_[:alpha:]][_[:alnum:]]*
@@ -2935,15 +2935,15 @@ repository:
     begin: '''
       (?x)
       (new)\\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -2971,15 +2971,15 @@ repository:
     match: '''
       (?x)
       (new)\\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3001,15 +3001,15 @@ repository:
     begin: '''
       (?x)
       \\b(new|stackalloc)\\b\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3106,16 +3106,16 @@ repository:
     match: '''
       (?x)
       (?:(?:\\b(ref|params|out|in|this)\\b)\\s+)?
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\\s+)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3205,15 +3205,15 @@ repository:
     begin: '''
       (?x)
       \\b(from)\\b\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3310,15 +3310,15 @@ repository:
     begin: '''
       (?x)
       \\b(join)\\b\\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3569,15 +3569,15 @@ repository:
     match: '''
       (?x)
       (?:\\b(ref|out|in)\\b)?\\s*
-      (?:(?<type-name>
+      (?:(?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
@@ -3655,22 +3655,22 @@ repository:
   "tuple-element":
     match: '''
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \\g<identifier>\\s*
-              (?<type-args>\\s*<(?:[^<>]|\\g<type-args>)+>\\s*)?
+              (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
             )
-            (?:\\s*\\.\\s*\\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
           (?:\\s*\\?\\s*)? # nullable suffix?
           (?:\\s*\\[(?:\\s*,\\s*)*\\]\\s*)* # array suffix?
         )
       )
-      (?:(?<tuple-name>\\g<identifier>)\\b)?
+      (?:(?<tuple_name>\\g<identifier>)\\b)?
     '''
     captures:
       "1":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -266,16 +266,16 @@ repository:
     begin: |-
       (?x)
       (?:\b(delegate)\b)\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\s+(?:readonly\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -291,8 +291,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.type.delegate.cs }
       '8':
@@ -451,15 +451,15 @@ repository:
   field-declaration:
     begin: |-
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -473,8 +473,8 @@ repository:
         patterns:
         - include: '#type'
       # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '3': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '4': ?<type_args> is a sub-expression. It's final value is not considered.
       # '5': ?<tuple> is a sub-expression. It's final value is not considered.
       '6': { name: entity.name.variable.field.cs }
     end: (?=;)
@@ -494,17 +494,17 @@ repository:
       # or other declarations as properties.
       (?![[:word:][:space:]]*\b(?:class|interface|struct|enum|event)\b)
 
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -512,17 +512,17 @@ repository:
           )
         )\s+
       )
-      (?<interface-name>\g<type-name>\s*\.\s*)?
-      (?<property-name>\g<identifier>)\s*
+      (?<interface_name>\g<type_name>\s*\.\s*)?
+      (?<property_name>\g<identifier>)\s*
       (?=\{|=>|$)
     beginCaptures:
       '1':
         patterns:
         - include: '#type'
-      # '2': ?<type-name> is a sub-expression. It's final value is not considered.
+      # '2': ?<type_name> is a sub-expression. It's final value is not considered.
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7':
         patterns:
@@ -540,17 +540,17 @@ repository:
   indexer-declaration:
     begin: |-
       (?x)
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -558,17 +558,17 @@ repository:
           )
         )\s+
       )
-      (?<interface-name>\g<type-name>\s*\.\s*)?
-      (?<indexer-name>this)\s*
+      (?<interface_name>\g<type_name>\s*\.\s*)?
+      (?<indexer_name>this)\s*
       (?=\[)
     beginCaptures:
       '1':
         patterns:
         - include: '#type'
-      # '2': ?<type-name> is a sub-expression. It's final value is not considered.
+      # '2': ?<type_name> is a sub-expression. It's final value is not considered.
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7':
         patterns:
@@ -588,16 +588,16 @@ repository:
     begin: |-
       (?x)
       \b(event)\b\s*
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -605,18 +605,18 @@ repository:
           )
         )\s+
       )
-      (?<interface-name>\g<type-name>\s*\.\s*)?
-      (?<event-names>\g<identifier>(?:\s*,\s*\g<identifier>)*)\s*
+      (?<interface_name>\g<type_name>\s*\.\s*)?
+      (?<event_names>\g<identifier>(?:\s*,\s*\g<identifier>)*)\s*
       (?=\{|;|$)
     beginCaptures:
       '1': { name: keyword.other.event.cs }
       '2':
         patterns:
         - include: '#type'
-      # '3': ?<type-name> is a sub-expression. It's final value is not considered.
+      # '3': ?<type_name> is a sub-expression. It's final value is not considered.
       # '4': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '5': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '6': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '5': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '6': ?<type_args> is a sub-expression. It's final value is not considered.
       # '7': ?<tuple> is a sub-expression. It's final value is not considered.
       '8':
         patterns:
@@ -674,17 +674,17 @@ repository:
   method-declaration:
     begin: |-
       (?x)
-      (?<return-type>
-        (?<type-name>
+      (?<return_type>
+        (?<type_name>
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref return
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -692,7 +692,7 @@ repository:
           )
         )\s+
       )
-      (?<interface-name>\g<type-name>\s*\.\s*)?
+      (?<interface_name>\g<type_name>\s*\.\s*)?
       (\g<identifier>)\s*
       (<([^<>]+)>)?\s*
       (?=\()
@@ -700,10 +700,10 @@ repository:
       '1':
         patterns:
         - include: '#type'
-      # '2': ?<type-name> is a sub-expression. It's final value is not considered.
+      # '2': ?<type_name> is a sub-expression. It's final value is not considered.
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7':
         patterns:
@@ -764,23 +764,23 @@ repository:
   operator-declaration:
     begin: |-
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\s+(?:readonly\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
       )\s*
-      (?<operator-keyword>(?:\b(?:operator)))\s*
+      (?<operator_keyword>(?:\b(?:operator)))\s*
       (?<operator>(?:\+|-|\*|/|%|&|\||\^|\<\<|\>\>|==|!=|\>|\<|\>=|\<=|!|~|\+\+|--|true|false))\s*
       (?=\()
     beginCaptures:
@@ -788,8 +788,8 @@ repository:
         patterns:
         - include: '#type'
       # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '3': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '4': ?<type_args> is a sub-expression. It's final value is not considered.
       # '5': ?<tuple> is a sub-expression. It's final value is not considered.
       '6': { name: keyword.other.operator-decl.cs }
       '7': { name: entity.name.function.cs }
@@ -803,18 +803,18 @@ repository:
   conversion-operator-declaration:
     begin: |-
       (?x)
-      (?<explicit-or-implicit-keyword>(?:\b(?:explicit|implicit)))\s*
-      (?<operator-keyword>(?:\b(?:operator)))\s*
-      (?<type-name>
+      (?<explicit_or_implicit_keyword>(?:\b(?:explicit|implicit)))\s*
+      (?<operator_keyword>(?:\b(?:operator)))\s*
+      (?<type_name>
         (?:
           (?:ref\s+(?:readonly\s+)?)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1064,15 +1064,15 @@ repository:
           (?x)
           (?:
             (\bvar\b)|
-            (?<type-name>
+            (?<type_name>
               (?:
                 (?:
                   (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-                  (?<name-and-type-args> # identifier + type arguments (if any)
+                  (?<name_and_type_args> # identifier + type arguments (if any)
                     \g<identifier>\s*
-                    (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                    (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
                   )
-                  (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+                  (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
                   (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
                 )
                 (?:\s*\?\s*)? # nullable suffix?
@@ -1088,8 +1088,8 @@ repository:
             patterns:
             - include: '#type'
           # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-          # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-          # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+          # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+          # '5': ?<type_args> is a sub-expression. It's final value is not considered.
           # '6': ?<tuple> is a sub-expression. It's final value is not considered.
           '7': { name: entity.name.variable.local.cs }
           '8': { name: keyword.control.loop.in.cs }
@@ -1146,15 +1146,15 @@ repository:
       patterns:
       - match: |-
           (?x)
-          (?<type-name>
+          (?<type_name>
             (?:
               (?:
                 (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-                (?<name-and-type-args> # identifier + type arguments (if any)
+                (?<name_and_type_args> # identifier + type arguments (if any)
                   \g<identifier>\s*
-                  (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                  (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
                 )
-                (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+                (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
                 (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
               )
               (?:\s*\?\s*)? # nullable suffix?
@@ -1167,8 +1167,8 @@ repository:
             patterns:
             - include: '#type'
           # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-          # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-          # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+          # '3': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+          # '4': ?<type_args> is a sub-expression. It's final value is not considered.
           # '5': ?<tuple> is a sub-expression. It's final value is not considered.
           '6': { name: entity.name.variable.local.cs }
     - include: '#when-clause'
@@ -1247,16 +1247,16 @@ repository:
       (?x)
       (?:
         (?:(\bref)\s+(?:(\breadonly)\s+)?)?(\bvar\b)| # ref local
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:ref\s+(?:readonly\s+)?)?   # ref local
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -1275,8 +1275,8 @@ repository:
         patterns:
         - include: '#type'
       # '5': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '6': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '7': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '6': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '7': ?<type_args> is a sub-expression. It's final value is not considered.
       # '8': ?<tuple> is a sub-expression. It's final value is not considered.
       '9': { name: entity.name.variable.local.cs }
     end: (?=;|\))
@@ -1290,16 +1290,16 @@ repository:
   local-constant-declaration:
     begin: |-
       (?x)
-      (?<const-keyword>\b(?:const)\b)\s*
-      (?<type-name>
+      (?<const_keyword>\b(?:const)\b)\s*
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1314,8 +1314,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.local.cs }
     end: (?=;)
@@ -1395,15 +1395,15 @@ repository:
       (?x) # e.g. int x OR var x
       (?:
         \b(var)\b|
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -1419,8 +1419,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.local.cs }
 
@@ -1429,15 +1429,15 @@ repository:
       (?x) # e.g. int x OR var x
       (?:
         \b(var)\b|
-        (?<type-name>
+        (?<type_name>
           (?:
             (?:
               (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-              (?<name-and-type-args> # identifier + type arguments (if any)
+              (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
               )
-              (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+              (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
               (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
             )
             (?:\s*\?\s*)? # nullable suffix?
@@ -1453,8 +1453,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.tuple-element.cs }
 
@@ -1720,15 +1720,15 @@ repository:
     match: |-
       (?x)
       (\()\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1742,8 +1742,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: punctuation.parenthesis.close.cs }
 
@@ -1751,15 +1751,15 @@ repository:
     match: |-
       (?x)
       (?<!\.)\b(as)\b\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1776,15 +1776,15 @@ repository:
     match: |-
       (?x)
       (?<!\.)\b(is)\b\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1809,7 +1809,7 @@ repository:
       (?:(\?)\s*)?                                     # preceding null-conditional operator?
       (?:(\.)\s*)?                                     # preceding dot?
       (@?[_[:alpha:]][_[:alnum:]]*)\s*                   # method name
-      (?<type-args>\s*<([^<>]|\g<type-args>)+>\s*)?\s* # type arguments
+      (?<type_args>\s*<([^<>]|\g<type_args>)+>\s*)?\s* # type arguments
       (?=\()                                           # open paren of argument list
     beginCaptures:
       '1': { name: keyword.operator.null-conditional.cs }
@@ -1859,7 +1859,7 @@ repository:
         (?x)
         (\.)?\s*
         (@?[_[:alpha:]][_[:alnum:]]*)
-        (?<type-params>\s*<([^<>]|\g<type-params>)+>\s*)
+        (?<type_params>\s*<([^<>]|\g<type_params>)+>\s*)
         (?=
           (\s*\?)?
           \s*\.\s*@?[_[:alpha:]][_[:alnum:]]*
@@ -1891,15 +1891,15 @@ repository:
     begin: |-
       (?x)
       (new)\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1920,15 +1920,15 @@ repository:
     match: |-
       (?x)
       (new)\s+
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -1946,15 +1946,15 @@ repository:
     begin: |-
       (?x)
       \b(new|stackalloc)\b\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -2015,16 +2015,16 @@ repository:
     match: |-
       (?x)
       (?:(?:\b(ref|params|out|in|this)\b)\s+)?
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:ref\s+)?   # ref return
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -2038,8 +2038,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.parameter.cs }
 
@@ -2087,15 +2087,15 @@ repository:
     begin: |-
       (?x)
       \b(from)\b\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -2110,8 +2110,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.range-variable.cs }
       '8': { name: keyword.query.in.cs }
@@ -2159,15 +2159,15 @@ repository:
     begin: |-
       (?x)
       \b(join)\b\s*
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -2182,8 +2182,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.range-variable.cs }
       '8': { name: keyword.query.in.cs }
@@ -2327,15 +2327,15 @@ repository:
     match: |-
       (?x)
       (?:\b(ref|out|in)\b)?\s*
-      (?:(?<type-name>
+      (?:(?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
@@ -2350,8 +2350,8 @@ repository:
         patterns:
         - include: '#type'
       # '3': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '4': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '5': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '4': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '5': ?<type_args> is a sub-expression. It's final value is not considered.
       # '6': ?<tuple> is a sub-expression. It's final value is not considered.
       '7': { name: entity.name.variable.parameter.cs }
 
@@ -2390,29 +2390,29 @@ repository:
   tuple-element:
     match: |-
       (?x)
-      (?<type-name>
+      (?<type_name>
         (?:
           (?:
             (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
               \g<identifier>\s*
-              (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+              (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
           (?:\s*\?\s*)? # nullable suffix?
           (?:\s*\[(?:\s*,\s*)*\]\s*)* # array suffix?
         )
       )
-      (?:(?<tuple-name>\g<identifier>)\b)?
+      (?:(?<tuple_name>\g<identifier>)\b)?
     captures:
       '1':
         patterns:
         - include: '#type'
       # '2': ?<identifier> is a sub-expression. It's final value is not considered.
-      # '3': ?<name-and-type-args> is a sub-expression. It's final value is not considered.
-      # '4': ?<type-args> is a sub-expression. It's final value is not considered.
+      # '3': ?<name_and_type_args> is a sub-expression. It's final value is not considered.
+      # '4': ?<type_args> is a sub-expression. It's final value is not considered.
       # '5': ?<tuple> is a sub-expression. It's final value is not considered.
       '6': { name: entity.name.variable.tuple-element.cs }
 

--- a/src/syntax.md
+++ b/src/syntax.md
@@ -8,16 +8,16 @@
 #### Type name
 
 ```
-(?<type-name>
+(?<type_name>
     (?:
         (?:ref\s+)?   # only in certain place with ref local/return
         (?:
             (?:(?<identifier>[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
-            (?<name-and-type-args> # identifier + type arguments (if any)
+            (?<name_and_type_args> # identifier + type arguments (if any)
                 \g<identifier>\s*
-                (?<type-args>\s*<(?:[^<>]|\g<type-args>)+>\s*)?
+                (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
             )
-            (?:\s*\.\s*\g<name-and-type-args>)* | # Are there any more names being dotted into?
+            (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
         )
         (?:\s*\*\s*)* # pointer suffix?


### PR DESCRIPTION
Among other differences between oniguruma and PCRE regex -- which are potentially inapplicable to the limited oniguruma syntax used in this repo -- PCRE does not support hyphen `-` in group names.

This change updates all the names to have underscore instead of hyphen to make the grammars PCRE compatible.

This will help official grammar sources from this repo to be directly consumed in GitHub linguist (which only supports PCRE regex), rather than going through atom repo, which only transforms grammar files from this repo by replacing `-` with `''`. ref:
* https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/.gitmodules#L505
* https://github.com/atom/language-csharp/blob/c65b4475d622077390fa9678a4fa2b3a84c2dc9c/scripts/converter.py#L14-L15 (transforming C# grammar from this repo to make it PCRE compatible)

The reason is that atom/language-csharp repo hasn't been updated in a while (someone sent a PR in atom repo almost an year ago, and it remains unattended) which impedes catching up with the pace of advancement been made in C# language.

#### Before (oniguruma compatible grammar only)
[https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&sc...](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcsharp-tmLanguage%2Fblob%2Fc01ee3c348807516b70a462657b6930876cb83f7%2Fgrammars%2Fcsharp.tmLanguage.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fruntime%2Fblob%2F9c472545df220d7ae26329e1649f880c4ee127e8%2Fsrc%2Flibraries%2FSystem.Memory%2Fsrc%2FSystem%2FBuffers%2FMemoryPool.cs&code=)

#### After (this PR; oniguruma as well as PCRE compatible grammar)
[https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&sc...](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fam11%2Fcsharp-tmLanguage%2F3791d32e8a80418b2fd7e72f2e7b7ca5a734ca05%2Fgrammars%2Fcsharp.tmLanguage.cson&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fruntime%2Fblob%2F9c472545df220d7ae26329e1649f880c4ee127e8%2Fsrc%2Flibraries%2FSystem.Memory%2Fsrc%2FSystem%2FBuffers%2FMemoryPool.cs&code=)


cc @DustinCampbell, @jaredpar, PTAL. I intend to send a PR to GitHub linguist repo, once/if these changes are in. 