### PR TITLE
Add syntax highlighting for records and init accessors

### DIFF
--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -41,6 +41,7 @@ repository:
     - include: '#delegate-declaration'
     - include: '#enum-declaration'
     - include: '#interface-declaration'
+    - include: '#record-declaration'
     - include: '#struct-declaration'
     - include: '#attribute-section'
     - include: '#punctuation-semicolon'
@@ -379,6 +380,34 @@ repository:
     - include: '#preprocessor'
     - include: '#comment'
 
+  record-declaration:
+    begin: (?=\brecord\b)
+    end: (?<=\})
+    patterns:
+    - begin: |-
+        (?x)
+        (struct)\b\s+
+        (@?[_[:alpha:]][_[:alnum:]]*)
+      beginCaptures:
+        '1': { name: keyword.other.record.cs }
+        '2': { name: entity.name.type.record.cs }
+      end: (?=\{)
+      patterns:
+      - include: '#comment'
+      - include: '#type-parameter-list'
+      - include: '#base-types'
+      - include: '#generic-constraints'
+    - begin: \{
+      beginCaptures:
+        '0': { name: punctuation.curlybrace.open.cs }
+      end: \}
+      endCaptures:
+        '0': { name: punctuation.curlybrace.close.cs }
+      patterns:
+      - include: '#class-or-struct-members'
+    - include: '#preprocessor'
+    - include: '#comment'
+
   struct-declaration:
     begin: (?=\bstruct\b)
     end: (?<=\})
@@ -683,6 +712,8 @@ repository:
       match: \b(get)\b
     - name: keyword.other.set.cs
       match: \b(set)\b
+    - name: keyword.other.init.cs
+      match: \b(init)\b
     - include: '#comment'
     - include: '#attribute-section'
     - include: '#expression-body'

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -386,7 +386,7 @@ repository:
     patterns:
     - begin: |-
         (?x)
-        (struct)\b\s+
+        (record)\b\s+
         (@?[_[:alpha:]][_[:alnum:]]*)
       beginCaptures:
         '1': { name: keyword.other.record.cs }


### PR DESCRIPTION
This pull request adds syntax highlighting for records and init accessors.
It currently doesn't include positional record declarations as I haven't figured them out yet regex-wise.

This partly addresses #202 (Records highlighting is not supported).