### PR TITLE
Add trailing word boundary in switch expression

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -2876,7 +2876,7 @@
       <key>switch-expression</key>
       <dict>
         <key>begin</key>
-        <string>(?x) (?&lt;!\.)\b(switch)</string>
+        <string>(?x) (?&lt;!\.)\b(switch)\b</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -1804,7 +1804,7 @@ repository:
       }
     ]
   "switch-expression":
-    begin: "(?x) (?<!\\.)\\b(switch)"
+    begin: "(?x) (?<!\\.)\\b(switch)\\b"
     beginCaptures:
       "1":
         name: "keyword.control.switch.cs"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1081,7 +1081,7 @@ repository:
       - include: '#statement'
 
   switch-expression:
-    begin: (?x) (?<!\.)\b(switch)
+    begin: (?x) (?<!\.)\b(switch)\b
     beginCaptures:
       '1': { name: keyword.control.switch.cs }
     end: (?<=\})


### PR DESCRIPTION
[Before (`3237bab`)](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcsharp-tmLanguage%2Fblob%2F3237bab%2Fgrammars%2Fcsharp.tmLanguage&grammar_text=&code_source=from-text&code_url=&code=switchfoo+%3D+bar%3B) vs. [After (`38c4bf0`)](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcsharp-tmLanguage%2Fblob%2F38c4bf0%2Fgrammars%2Fcsharp.tmLanguage&grammar_text=&code_source=from-text&code_url=&code=switchfoo+%3D+bar%3B).