### PR TITLE
Allow spaces in null conditional classification

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -5207,7 +5207,7 @@
       <key>conditional-operator</key>
       <dict>
         <key>begin</key>
-        <string>(?&lt;!\?)\?(?!\?|\.|\[)</string>
+        <string>(?&lt;!\?\s*)\?(?!\?|\.|\[)</string>
         <key>beginCaptures</key>
         <dict>
           <key>0</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3159,7 +3159,7 @@ repository:
       }
     ]
   "conditional-operator":
-    begin: "(?<!\\?)\\?(?!\\?|\\.|\\[)"
+    begin: "(?<!\\?\\s*)\\?(?!\\?|\\.|\\[)"
     beginCaptures:
       "0":
         name: "keyword.operator.conditional.question-mark.cs"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2035,7 +2035,7 @@ repository:
     # Only match ? if:
     # 1. There isn't a preceding or trailing ? (null-coalescing operator)
     # 2. There isn't a trailing . or [ (null-conditional operator)
-    begin: (?<!\?)\?(?!\?|\.|\[)
+    begin: (?<!\?\s*)\?(?!\?|\.|\[)
     beginCaptures:
       '0': { name: keyword.operator.conditional.question-mark.cs }
     end: ':'


### PR DESCRIPTION
[Before (`3237bab`)](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcsharp-tmLanguage%2Fblob%2F3237bab%2Fsrc%2Fcsharp.tmLanguage.yml&grammar_text=&code_source=from-text&code_url=&code=public+class+A+%7B%0D%0A++++public+void+X1%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++s+++%3F++.+Trim%28%29%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X2%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++char%3F+x+%3D+s+++%3F+++%5B+++0%5D%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X1%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++s++++%3F%0D%0A++++++++++.+++++Trim%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X2%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++char%3F+x+%3D+s+++%3F%0D%0A+++++++++++++++%5B++++0%5D%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A%7D) vs. [After (`c724205`)](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fcsharp-tmLanguage%2Fblob%2Fc724205%2Fgrammars%2Fcsharp.tmLanguage&grammar_text=&code_source=from-text&code_url=&code=public+class+A+%7B%0D%0A++++public+void+X1%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++s+++%3F++.+Trim%28%29%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X2%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++char%3F+x+%3D+s+++%3F+++%5B+++0%5D%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X1%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++s++++%3F%0D%0A++++++++++.+++++Trim%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A++++public+void+X2%28%29+%7B%0D%0A++++++++string+s+%3D+null%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++++++char%3F+x+%3D+s+++%3F%0D%0A+++++++++++++++%5B++++0%5D%3B%0D%0A++++++++if+%28true%29+%7B%7D%0D%0A++++%7D%0D%0A%7D).

Fixes #207