### PR TITLE
Avoid variable length lookbehind

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 To **build and test** install Node.js do the following:
 
 * Run `npm install` to install any dependencies.
-* Run `gulp` to build and run tests.
+* Run `npm run compile` to build and run tests.
 
 Output grammars are output in the `grammars\` directory.
 

--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -5207,7 +5207,7 @@
       <key>conditional-operator</key>
       <dict>
         <key>begin</key>
-        <string>(?&lt;!\?\s*)\?(?!\?|\.|\[)</string>
+        <string>\?(?!\s*[?.\[]|\s*$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>0</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3159,7 +3159,7 @@ repository:
       }
     ]
   "conditional-operator":
-    begin: "(?<!\\?\\s*)\\?(?!\\?|\\.|\\[)"
+    begin: "\\?(?!\\s*[?.\\[]|\\s*$)"
     beginCaptures:
       "0":
         name: "keyword.operator.conditional.question-mark.cs"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2035,7 +2035,7 @@ repository:
     # Only match ? if:
     # 1. There isn't a preceding or trailing ? (null-coalescing operator)
     # 2. There isn't a trailing . or [ (null-conditional operator)
-    begin: (?<!\?\s*)\?(?!\?|\.|\[)
+    begin: \?(?!\s*[?.\[]|\s*$)
     beginCaptures:
       '0': { name: keyword.operator.conditional.question-mark.cs }
     end: ':'


### PR DESCRIPTION
* GH Linguist supports PCRE grammar, which supports variable (as well as fixed) length lookbehind.
* VSCode supports Oniguruma grammar, which only support fixed length lookbehind.

so the solution to keep both worlds happy is to use most common syntax; fixed length lookbehind.