### PR TITLE
Add support for file-scoped namespaces

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -750,7 +750,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?&lt;=\})</string>
+        <string>(?&lt;=\})|(?=;)</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -487,7 +487,7 @@ repository:
     beginCaptures:
       "1":
         name: "keyword.other.namespace.cs"
-    end: "(?<=\\})"
+    end: "(?<=\\})|(?=;)"
     patterns: [
       {
         include: "#comment"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -218,7 +218,7 @@ repository:
     begin: \b(namespace)\s+
     beginCaptures:
       '1': { name: keyword.other.namespace.cs }
-    end: (?<=\})
+    end: (?<=\})|(?=;)
     patterns:
     - include: '#comment'
     - name: entity.name.type.namespace.cs


### PR DESCRIPTION
This pr adds support for file scoped namespaces.

Currently file scoped namespaces break syntax highlighting until the next pair of braces, as shown below.

```csharp
namespace MyProject;

class Test { }
```
_how it looks_
```csharp
namespace MyProject 
{
    class Test { }
}
```
_how it should look_


I have not added any tests yet as I couldn't figure out how to do it just by looking at the existing testing code.