### PR TITLE
fix #244

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -4950,7 +4950,7 @@
       <key>numeric-literal</key>
       <dict>
         <key>match</key>
-        <string>(?&lt;!\w)\.?\d(?:(?:[0-9a-zA-Z_\.]|_)|(?&lt;=[eE])[+-])*</string>
+        <string>(?&lt;!\w)\.?\d(?:(?:[0-9a-zA-Z_]|_)|(?&lt;=[eE])[+-]|\.\d)*</string>
         <key>captures</key>
         <dict>
           <key>0</key>
@@ -5182,7 +5182,7 @@
                   </dict>
                   <dict>
                     <key>match</key>
-                    <string>(?:(?:[0-9a-zA-Z_\.]|_)|(?&lt;=[eE])[+-])+</string>
+                    <string>(?:(?:[0-9a-zA-Z_]|_)|(?&lt;=[eE])[+-]|\.\d)+</string>
                     <key>name</key>
                     <string>invalid.illegal.constant.numeric.cs</string>
                   </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3013,7 +3013,7 @@ repository:
     name: "constant.language.null.cs"
     match: "(?<!\\.)\\bnull\\b"
   "numeric-literal":
-    match: "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|_)|(?<=[eE])[+-])*"
+    match: "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_]|_)|(?<=[eE])[+-]|\\.\\d)*"
     captures:
       "0":
         patterns: [
@@ -3130,7 +3130,7 @@ repository:
                     name: "constant.numeric.other.suffix.cs"
               }
               {
-                match: "(?:(?:[0-9a-zA-Z_\\.]|_)|(?<=[eE])[+-])+"
+                match: "(?:(?:[0-9a-zA-Z_]|_)|(?<=[eE])[+-]|\\.\\d)+"
                 name: "invalid.illegal.constant.numeric.cs"
               }
             ]

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1927,7 +1927,7 @@ repository:
     match: (?<!\.)\bnull\b
 
   numeric-literal:
-    match: "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_\\.]|_)|(?<=[eE])[+-])*"
+    match: "(?<!\\w)\\.?\\d(?:(?:[0-9a-zA-Z_]|_)|(?<=[eE])[+-]|\\.\\d)*"
     captures:
       '0':
         patterns:
@@ -2018,7 +2018,7 @@ repository:
               '9':
                 name: constant.numeric.other.suffix.cs
           # Capture the rest as an invalid numeric literal
-          - match: "(?:(?:[0-9a-zA-Z_\\.]|_)|(?<=[eE])[+-])+"
+          - match: "(?:(?:[0-9a-zA-Z_]|_)|(?<=[eE])[+-]|\\.\\d)+"
             name: invalid.illegal.constant.numeric.cs
 
   char-literal:

--- a/test/literals.tests.ts
+++ b/test/literals.tests.ts
@@ -511,15 +511,38 @@ describe("Literals", () => {
                 ]);
             });
 
-            it("invalid illegal constant numeric - decimal point separator with no decimal part", async () => {
-                const input = Input.InMethod(`var x = 5.f;`);
+            it("legal constant numeric followed by a method call", async () => {
+                const input = Input.InMethod(`var x = 5.f();`);
                 const tokens = await tokenize(input);
                 
                 tokens.should.deep.equal([
                     Token.Keywords.Var,
                     Token.Identifiers.LocalName("x"),
                     Token.Operators.Assignment,
-                    Token.Literals.Numeric.Invalid("5.f"),
+                    Token.Literals.Numeric.Decimal("5"),
+                    Token.Punctuation.Accessor,
+                    Token.Identifiers.MethodName("f"),
+                    Token.Punctuation.OpenParen,
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon
+                ]);
+            });
+
+            it("legal constant numeric containing decimal point followed by a method call", async () => {
+                const input = Input.InMethod(`var pi = 3.14.ToString();`);
+                const tokens = await tokenize(input);
+                
+                tokens.should.deep.equal([
+                    Token.Keywords.Var,
+                    Token.Identifiers.LocalName("pi"),
+                    Token.Operators.Assignment,
+                    Token.Literals.Numeric.Decimal("3"),                   
+                    Token.Literals.Numeric.Other.Separator.Decimals,
+                    Token.Literals.Numeric.Decimal("14"),                   
+                     Token.Punctuation.Accessor,
+                    Token.Identifiers.MethodName("ToString"),
+                    Token.Punctuation.OpenParen,
+                    Token.Punctuation.CloseParen,
                     Token.Punctuation.Semicolon
                 ]);
             });


### PR DESCRIPTION
Periods not followed by a number shall not be treated as part of a numeric literal they touch.
This is because member access would otherwise be falsely flagged as illegal syntax.

This should fix issue #244.