### PR TITLE
Add support for primary constructors

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -129,11 +129,11 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#record-declaration</string>
+            <string>#struct-declaration</string>
           </dict>
           <dict>
             <key>include</key>
-            <string>#struct-declaration</string>
+            <string>#record-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -820,31 +820,37 @@
       <key>class-declaration</key>
       <dict>
         <key>begin</key>
-        <string>(?=\bclass\b)</string>
+        <string>(?=(\brecord\b\s+)?\bclass\b)</string>
         <key>end</key>
-        <string>(?&lt;=\})</string>
+        <string>(?&lt;=\})|(?=;)</string>
         <key>patterns</key>
         <array>
           <dict>
             <key>begin</key>
             <string>(?x)
+(\b(record)\b\s+)?
 \b(class)\b\s+
 (@?[_[:alpha:]][_[:alnum:]]*)\s*</string>
             <key>beginCaptures</key>
             <dict>
-              <key>1</key>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.record.cs</string>
+              </dict>
+              <key>3</key>
               <dict>
                 <key>name</key>
                 <string>keyword.other.class.cs</string>
               </dict>
-              <key>2</key>
+              <key>4</key>
               <dict>
                 <key>name</key>
                 <string>entity.name.type.class.cs</string>
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=\{)</string>
+            <string>(?=\{)|(?=;)</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -854,6 +860,10 @@
               <dict>
                 <key>include</key>
                 <string>#type-parameter-list</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#parenthesized-parameter-list</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -1213,7 +1223,7 @@
         <key>begin</key>
         <string>(?=\brecord\b)</string>
         <key>end</key>
-        <string>(?&lt;=\})</string>
+        <string>(?&lt;=\})|(?=;)</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -1231,11 +1241,11 @@
               <key>2</key>
               <dict>
                 <key>name</key>
-                <string>entity.name.type.record.cs</string>
+                <string>entity.name.type.class.cs</string>
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=\{)</string>
+            <string>(?=\{)|(?=;)</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -1245,6 +1255,10 @@
               <dict>
                 <key>include</key>
                 <string>#type-parameter-list</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#parenthesized-parameter-list</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -1298,31 +1312,37 @@
       <key>struct-declaration</key>
       <dict>
         <key>begin</key>
-        <string>(?=\bstruct\b)</string>
+        <string>(?=(\brecord\b\s+)?\bstruct\b)</string>
         <key>end</key>
-        <string>(?&lt;=\})</string>
+        <string>(?&lt;=\})|(?=;)</string>
         <key>patterns</key>
         <array>
           <dict>
             <key>begin</key>
             <string>(?x)
+(\b(record)\b\s+)?
 (struct)\b\s+
 (@?[_[:alpha:]][_[:alnum:]]*)</string>
             <key>beginCaptures</key>
             <dict>
-              <key>1</key>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.other.record.cs</string>
+              </dict>
+              <key>3</key>
               <dict>
                 <key>name</key>
                 <string>keyword.other.struct.cs</string>
               </dict>
-              <key>2</key>
+              <key>4</key>
               <dict>
                 <key>name</key>
                 <string>entity.name.type.struct.cs</string>
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=\{)</string>
+            <string>(?=\{)|(?=;)</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -1332,6 +1352,10 @@
               <dict>
                 <key>include</key>
                 <string>#type-parameter-list</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#parenthesized-parameter-list</string>
               </dict>
               <dict>
                 <key>include</key>
@@ -1457,7 +1481,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=\{|where)</string>
+        <string>(?=\{|where|;)</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -85,10 +85,10 @@ repository:
         include: "#interface-declaration"
       }
       {
-        include: "#record-declaration"
+        include: "#struct-declaration"
       }
       {
-        include: "#struct-declaration"
+        include: "#record-declaration"
       }
       {
         include: "#attribute-section"
@@ -528,27 +528,33 @@ repository:
     name: "storage.modifier.cs"
     match: "(?<!\\.)\\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref|required)\\b"
   "class-declaration":
-    begin: "(?=\\bclass\\b)"
-    end: "(?<=\\})"
+    begin: "(?=(\\brecord\\b\\s+)?\\bclass\\b)"
+    end: "(?<=\\})|(?=;)"
     patterns: [
       {
         begin: '''
           (?x)
+          (\\b(record)\\b\\s+)?
           \\b(class)\\b\\s+
           (@?[_[:alpha:]][_[:alnum:]]*)\\s*
         '''
         beginCaptures:
-          "1":
-            name: "keyword.other.class.cs"
           "2":
+            name: "keyword.other.record.cs"
+          "3":
+            name: "keyword.other.class.cs"
+          "4":
             name: "entity.name.type.class.cs"
-        end: "(?=\\{)"
+        end: "(?=\\{)|(?=;)"
         patterns: [
           {
             include: "#comment"
           }
           {
             include: "#type-parameter-list"
+          }
+          {
+            include: "#parenthesized-parameter-list"
           }
           {
             include: "#base-types"
@@ -774,7 +780,7 @@ repository:
     ]
   "record-declaration":
     begin: "(?=\\brecord\\b)"
-    end: "(?<=\\})"
+    end: "(?<=\\})|(?=;)"
     patterns: [
       {
         begin: '''
@@ -786,14 +792,17 @@ repository:
           "1":
             name: "keyword.other.record.cs"
           "2":
-            name: "entity.name.type.record.cs"
-        end: "(?=\\{)"
+            name: "entity.name.type.class.cs"
+        end: "(?=\\{)|(?=;)"
         patterns: [
           {
             include: "#comment"
           }
           {
             include: "#type-parameter-list"
+          }
+          {
+            include: "#parenthesized-parameter-list"
           }
           {
             include: "#base-types"
@@ -826,27 +835,33 @@ repository:
       }
     ]
   "struct-declaration":
-    begin: "(?=\\bstruct\\b)"
-    end: "(?<=\\})"
+    begin: "(?=(\\brecord\\b\\s+)?\\bstruct\\b)"
+    end: "(?<=\\})|(?=;)"
     patterns: [
       {
         begin: '''
           (?x)
+          (\\b(record)\\b\\s+)?
           (struct)\\b\\s+
           (@?[_[:alpha:]][_[:alnum:]]*)
         '''
         beginCaptures:
-          "1":
-            name: "keyword.other.struct.cs"
           "2":
+            name: "keyword.other.record.cs"
+          "3":
+            name: "keyword.other.struct.cs"
+          "4":
             name: "entity.name.type.struct.cs"
-        end: "(?=\\{)"
+        end: "(?=\\{)|(?=;)"
         patterns: [
           {
             include: "#comment"
           }
           {
             include: "#type-parameter-list"
+          }
+          {
+            include: "#parenthesized-parameter-list"
           }
           {
             include: "#base-types"
@@ -915,7 +930,7 @@ repository:
     beginCaptures:
       "0":
         name: "punctuation.separator.colon.cs"
-    end: "(?=\\{|where)"
+    end: "(?=\\{|where|;)"
     patterns: [
       {
         include: "#type"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -41,8 +41,8 @@ repository:
     - include: '#delegate-declaration'
     - include: '#enum-declaration'
     - include: '#interface-declaration'
-    - include: '#record-declaration'
     - include: '#struct-declaration'
+    - include: '#record-declaration'
     - include: '#attribute-section'
     - include: '#punctuation-semicolon'
 
@@ -241,20 +241,23 @@ repository:
     match: (?<!\.)\b(new|public|protected|internal|private|abstract|virtual|override|sealed|static|partial|readonly|volatile|const|extern|async|unsafe|ref|required)\b
 
   class-declaration:
-    begin: (?=\bclass\b)
-    end: (?<=\})
+    begin: (?=(\brecord\b\s+)?\bclass\b)
+    end: (?<=\})|(?=;)
     patterns:
     - begin: |-
         (?x)
+        (\b(record)\b\s+)?
         \b(class)\b\s+
         (@?[_[:alpha:]][_[:alnum:]]*)\s*
       beginCaptures:
-        '1': { name: keyword.other.class.cs }
-        '2': { name: entity.name.type.class.cs }
-      end: (?=\{)
+        '2': { name: keyword.other.record.cs }
+        '3': { name: keyword.other.class.cs }
+        '4': { name: entity.name.type.class.cs }
+      end: (?=\{)|(?=;)
       patterns:
       - include: '#comment'
       - include: '#type-parameter-list'
+      - include: "#parenthesized-parameter-list"
       - include: '#base-types'
       - include: '#generic-constraints'
     - begin: \{
@@ -386,7 +389,7 @@ repository:
 
   record-declaration:
     begin: (?=\brecord\b)
-    end: (?<=\})
+    end: (?<=\})|(?=;)
     patterns:
     - begin: |-
         (?x)
@@ -394,11 +397,12 @@ repository:
         (@?[_[:alpha:]][_[:alnum:]]*)
       beginCaptures:
         '1': { name: keyword.other.record.cs }
-        '2': { name: entity.name.type.record.cs }
-      end: (?=\{)
+        '2': { name: entity.name.type.class.cs }
+      end: (?=\{)|(?=;)
       patterns:
       - include: '#comment'
       - include: '#type-parameter-list'
+      - include: "#parenthesized-parameter-list"
       - include: '#base-types'
       - include: '#generic-constraints'
     - begin: \{
@@ -413,20 +417,23 @@ repository:
     - include: '#comment'
 
   struct-declaration:
-    begin: (?=\bstruct\b)
-    end: (?<=\})
+    begin: (?=(\brecord\b\s+)?\bstruct\b)
+    end: (?<=\})|(?=;)
     patterns:
     - begin: |-
         (?x)
+        (\b(record)\b\s+)?
         (struct)\b\s+
         (@?[_[:alpha:]][_[:alnum:]]*)
       beginCaptures:
-        '1': { name: keyword.other.struct.cs }
-        '2': { name: entity.name.type.struct.cs }
-      end: (?=\{)
+        '2': { name: keyword.other.record.cs }
+        '3': { name: keyword.other.struct.cs }
+        '4': { name: entity.name.type.struct.cs }
+      end: (?=\{)|(?=;)
       patterns:
       - include: '#comment'
       - include: '#type-parameter-list'
+      - include: "#parenthesized-parameter-list"
       - include: '#base-types'
       - include: '#generic-constraints'
     - begin: \{
@@ -462,7 +469,7 @@ repository:
     begin: ':'
     beginCaptures:
       '0': { name: punctuation.separator.colon.cs }
-    end: (?=\{|where)
+    end: (?=\{|where|;)
     patterns:
     - include: '#type'
     - include: '#punctuation-comma'

--- a/test/class.tests.ts
+++ b/test/class.tests.ts
@@ -312,6 +312,136 @@ unsafe class C
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace]);
             });
+
+            it(`primary constructor (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+class Person(string name, int age);
+class Person2(string name, int age) { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor inheritance (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+class Person(string name, int age) : IPerson;
+class Person2(string name, int age) : IPerson { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Colon,
+                    Token.Type("IPerson"),
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Colon,
+                    Token.Type("IPerson"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor generic (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+class Person<T>(string name, int age, T tag) : IPerson
+    where T : new();
+class Person2<T>(string name, int age, T tag) : IPerson
+    where T : new() { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person"),
+                    Token.Punctuation.TypeParameters.Begin,
+                    Token.Identifiers.TypeParameterName("T"),
+                    Token.Punctuation.TypeParameters.End,
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.Comma,
+                    Token.Type("T"),
+                    Token.Identifiers.ParameterName("tag"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Colon,
+                    Token.Type("IPerson"),
+                    Token.Keywords.Where,
+                    Token.Identifiers.TypeParameterName("T"),
+                    Token.Punctuation.Colon,
+                    Token.Keywords.New,
+                    Token.Punctuation.OpenParen,
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person2"),
+                    Token.Punctuation.TypeParameters.Begin,
+                    Token.Identifiers.TypeParameterName("T"),
+                    Token.Punctuation.TypeParameters.End,
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.Comma,
+                    Token.Type("T"),
+                    Token.Identifiers.ParameterName("tag"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Colon,
+                    Token.Type("IPerson"),
+                    Token.Keywords.Where,
+                    Token.Identifiers.TypeParameterName("T"),
+                    Token.Punctuation.Colon,
+                    Token.Keywords.New,
+                    Token.Punctuation.OpenParen,
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
         }
     });
 });

--- a/test/record.tests.ts
+++ b/test/record.tests.ts
@@ -42,57 +42,57 @@ public    abstract record PublicAbstractRecord { }
                 tokens.should.deep.equal([
                     Token.Keywords.Modifiers.Public,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("DefaultRecord"),
+                    Token.Identifiers.ClassName("DefaultRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Internal,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("InternalRecord"),
+                    Token.Identifiers.ClassName("InternalRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Static,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("DefaultStaticRecord"),
+                    Token.Identifiers.ClassName("DefaultStaticRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Public,
                     Token.Keywords.Modifiers.Static,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicStaticRecord"),
+                    Token.Identifiers.ClassName("PublicStaticRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Sealed,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("DefaultSealedRecord"),
+                    Token.Identifiers.ClassName("DefaultSealedRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Public,
                     Token.Keywords.Modifiers.Sealed,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicSealedRecord"),
+                    Token.Identifiers.ClassName("PublicSealedRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Public,
                     Token.Keywords.Modifiers.Abstract,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicAbstractRecord"),
+                    Token.Identifiers.ClassName("PublicAbstractRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Modifiers.Abstract,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("DefaultAbstractRecord"),
+                    Token.Identifiers.ClassName("DefaultAbstractRecord"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace]);
             });
@@ -104,7 +104,7 @@ public    abstract record PublicAbstractRecord { }
 
                 tokens.should.deep.equal([
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("Dictionary"),
+                    Token.Identifiers.ClassName("Dictionary"),
                     Token.Punctuation.TypeParameters.Begin,
                     Token.Identifiers.TypeParameterName("TKey"),
                     Token.Punctuation.Comma,
@@ -125,7 +125,7 @@ record PublicRecord<T> : Dictionary<T, Dictionary<string, string>>, IMap<T, Dict
 
                 tokens.should.deep.equal([
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.Colon,
                     Token.Type("IInterface"),
                     Token.Punctuation.Comma,
@@ -134,7 +134,7 @@ record PublicRecord<T> : Dictionary<T, Dictionary<string, string>>, IMap<T, Dict
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.TypeParameters.Begin,
                     Token.Identifiers.TypeParameterName("T"),
                     Token.Punctuation.TypeParameters.End,
@@ -155,7 +155,7 @@ record PublicRecord<T> : Dictionary<T, Dictionary<string, string>>, IMap<T, Dict
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.TypeParameters.Begin,
                     Token.Identifiers.TypeParameterName("T"),
                     Token.Punctuation.TypeParameters.End,
@@ -200,7 +200,7 @@ record PublicRecord<T, X> : Dictionary<T, List<string>[]>, ISomething
 
                 tokens.should.deep.equal([
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.TypeParameters.Begin,
                     Token.Identifiers.TypeParameterName("T"),
                     Token.Punctuation.TypeParameters.End,
@@ -212,7 +212,7 @@ record PublicRecord<T, X> : Dictionary<T, List<string>[]>, ISomething
                     Token.Punctuation.CloseBrace,
 
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("PublicRecord"),
+                    Token.Identifiers.ClassName("PublicRecord"),
                     Token.Punctuation.TypeParameters.Begin,
                     Token.Identifiers.TypeParameterName("T"),
                     Token.Punctuation.Comma,
@@ -262,11 +262,11 @@ record Klass
 
                 tokens.should.deep.equal([
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("Klass"),
+                    Token.Identifiers.ClassName("Klass"),
                     Token.Punctuation.OpenBrace,
 
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("Nested"),
+                    Token.Identifiers.ClassName("Nested"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
@@ -287,12 +287,12 @@ record Klass
 
                 tokens.should.deep.equal([
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("Klass"),
+                    Token.Identifiers.ClassName("Klass"),
                     Token.Punctuation.OpenBrace,
 
                     Token.Keywords.Modifiers.Public,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("Nested"),
+                    Token.Identifiers.ClassName("Nested"),
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace,
 
@@ -309,7 +309,107 @@ unsafe record C
                 tokens.should.deep.equal([
                     Token.Keywords.Modifiers.Unsafe,
                     Token.Keywords.Record,
-                    Token.Identifiers.RecordName("C"),
+                    Token.Identifiers.ClassName("C"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor record (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+record Person(string name, int age);
+record Person2(string name, int age) { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Record,
+                    Token.Identifiers.ClassName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Record,
+                    Token.Identifiers.ClassName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor record class (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+record class Person(string name, int age);
+record class Person2(string name, int age) { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Record,
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Record,
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor record struct (${styleName} Namespace)`, async () => {
+
+                const input = Input.InNamespace(`
+record struct Person(string name, int age);
+record struct Person2(string name, int age) { }`
+                    , namespaceStyle);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Record,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Record,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
                     Token.Punctuation.OpenBrace,
                     Token.Punctuation.CloseBrace]);
             });

--- a/test/struct.tests.ts
+++ b/test/struct.tests.ts
@@ -4,48 +4,53 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { should } from 'chai';
-import { tokenize, Token } from './utils/tokenize';
+import { tokenize, Token, NamespaceStyle } from './utils/tokenize';
 
 describe("Structs", () => {
     before(() => { should(); });
 
     describe("Structs", () => {
-        it("simple struct", async () => {
+        for (const namespaceStyle of [NamespaceStyle.BlockScoped, NamespaceStyle.FileScoped]) {
+            const styleName = namespaceStyle == NamespaceStyle.BlockScoped
+                ? "Block-Scoped"
+                : "File-Scoped";
 
-            const input = `struct S { }`;
-            const tokens = await tokenize(input);
+            it(`simple struct (${styleName} Namespace)`, async () => {
 
-            tokens.should.deep.equal([
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                const input = `struct S { }`;
+                const tokens = await tokenize(input);
 
-        it("struct interface implementation", async () => {
+                tokens.should.deep.equal([
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
 
-            const input = `
+            it(`struct interface implementation (${styleName} Namespace)`, async () => {
+
+                const input = `
 interface IFoo { }
 struct S : IFoo { }
 `;
-            const tokens = await tokenize(input);
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Interface,
-                Token.Identifiers.InterfaceName("IFoo"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace,
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.Colon,
-                Token.Type("IFoo"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                tokens.should.deep.equal([
+                    Token.Keywords.Interface,
+                    Token.Identifiers.InterfaceName("IFoo"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.Colon,
+                    Token.Type("IFoo"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("nested struct", async () => {
+            it(`nested struct (${styleName} Namespace)`, async () => {
 
-            const input = `
+                const input = `
 class Klass
 {
     struct Nested
@@ -53,24 +58,24 @@ class Klass
 
     }
 }`;
-            const tokens = await tokenize(input);
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Class,
-                Token.Identifiers.ClassName("Klass"),
-                Token.Punctuation.OpenBrace,
+                tokens.should.deep.equal([
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Klass"),
+                    Token.Punctuation.OpenBrace,
 
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("Nested"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Nested"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace,
 
-                Token.Punctuation.CloseBrace]);
-        });
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("nested struct with modifier", async () => {
+            it(`nested struct with modifier (${styleName} Namespace)`, async () => {
 
-            const input = `
+                const input = `
 class Klass
 {
     public struct Nested
@@ -78,87 +83,119 @@ class Klass
 
     }
 }`;
-            const tokens = await tokenize(input);
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Class,
-                Token.Identifiers.ClassName("Klass"),
-                Token.Punctuation.OpenBrace,
+                tokens.should.deep.equal([
+                    Token.Keywords.Class,
+                    Token.Identifiers.ClassName("Klass"),
+                    Token.Punctuation.OpenBrace,
 
-                Token.Keywords.Modifiers.Public,
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("Nested"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace,
+                    Token.Keywords.Modifiers.Public,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Nested"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace,
 
-                Token.Punctuation.CloseBrace]);
-        });
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("generic struct", async () => {
+            it(`generic struct (${styleName} Namespace)`, async () => {
 
-            const input = `
+                const input = `
 struct S<T1, T2> { }
 `;
-            const tokens = await tokenize(input);
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.TypeParameters.Begin,
-                Token.Identifiers.TypeParameterName("T1"),
-                Token.Punctuation.Comma,
-                Token.Identifiers.TypeParameterName("T2"),
-                Token.Punctuation.TypeParameters.End,
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                tokens.should.deep.equal([
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.TypeParameters.Begin,
+                    Token.Identifiers.TypeParameterName("T1"),
+                    Token.Punctuation.Comma,
+                    Token.Identifiers.TypeParameterName("T2"),
+                    Token.Punctuation.TypeParameters.End,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("generic struct with constraints", async () => {
+            it(`generic struct with constraints (${styleName} Namespace)`, async () => {
 
-            const input = `
+                const input = `
 struct S<T1, T2> where T1 : T2 { }
 `;
-            const tokens = await tokenize(input);
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.TypeParameters.Begin,
-                Token.Identifiers.TypeParameterName("T1"),
-                Token.Punctuation.Comma,
-                Token.Identifiers.TypeParameterName("T2"),
-                Token.Punctuation.TypeParameters.End,
-                Token.Keywords.Where,
-                Token.Identifiers.TypeParameterName("T1"),
-                Token.Punctuation.Colon,
-                Token.Type("T2"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                tokens.should.deep.equal([
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.TypeParameters.Begin,
+                    Token.Identifiers.TypeParameterName("T1"),
+                    Token.Punctuation.Comma,
+                    Token.Identifiers.TypeParameterName("T2"),
+                    Token.Punctuation.TypeParameters.End,
+                    Token.Keywords.Where,
+                    Token.Identifiers.TypeParameterName("T1"),
+                    Token.Punctuation.Colon,
+                    Token.Type("T2"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("ref struct", async () => {
-            const input = `ref struct S { }`;
-            const tokens = await tokenize(input);
+            it(`ref struct (${styleName} Namespace)`, async () => {
+                const input = `ref struct S {}`;
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Modifiers.Ref,
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                tokens.should.deep.equal([
+                    Token.Keywords.Modifiers.Ref,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
 
-        it("readonly ref struct", async () => {
-            const input = `readonly ref struct S { }`;
-            const tokens = await tokenize(input);
+            it(`readonly ref struct(${styleName} Namespace)`, async () => {
+                const input = `readonly ref struct S {}`;
+                const tokens = await tokenize(input);
 
-            tokens.should.deep.equal([
-                Token.Keywords.Modifiers.ReadOnly,
-                Token.Keywords.Modifiers.Ref,
-                Token.Keywords.Struct,
-                Token.Identifiers.StructName("S"),
-                Token.Punctuation.OpenBrace,
-                Token.Punctuation.CloseBrace]);
-        });
+                tokens.should.deep.equal([
+                    Token.Keywords.Modifiers.ReadOnly,
+                    Token.Keywords.Modifiers.Ref,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("S"),
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+
+            it(`primary constructor struct (${styleName} Namespace)`, async () => {
+
+                const input = `
+struct Person(string name, int age);
+struct Person2(string name, int age) { } `;
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Person"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.Semicolon,
+                    Token.Keywords.Struct,
+                    Token.Identifiers.StructName("Person2"),
+                    Token.Punctuation.OpenParen,
+                    Token.PrimitiveType.String,
+                    Token.Identifiers.ParameterName("name"),
+                    Token.Punctuation.Comma,
+                    Token.PrimitiveType.Int,
+                    Token.Identifiers.ParameterName("age"),
+                    Token.Punctuation.CloseParen,
+                    Token.Punctuation.OpenBrace,
+                    Token.Punctuation.CloseBrace]);
+            });
+        }
     });
 });

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -237,7 +237,6 @@ export namespace Token {
         export const PreprocessorSymbol = (text: string) => createToken(text, 'entity.name.variable.preprocessor.symbol.cs');
         export const PropertyName = (text: string) => createToken(text, 'entity.name.variable.property.cs');
         export const RangeVariableName = (text: string) => createToken(text, 'entity.name.variable.range-variable.cs');
-        export const RecordName = (text: string) => createToken(text, 'entity.name.type.record.cs');
         export const StructName = (text: string) => createToken(text, 'entity.name.type.struct.cs');
         export const TupleElementName = (text: string) => createToken(text, 'entity.name.variable.tuple-element.cs');
         export const TypeParameterName = (text: string) => createToken(text, 'entity.name.type.type-parameter.cs');


### PR DESCRIPTION
- Add support for Class/Struct/Record declaration with no body.
- Add support for Class/Struct/Record declaration parameter list.
- Add support for `record class` and `record struct`.
- Remove RecordName identifier type. Instead use ClassName/StructName as necessary.