### PR TITLE
C# 9.0 target-typed new

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6096,7 +6096,7 @@
       <dict>
         <key>begin</key>
         <string>(?x)
-(new)\s+
+(new)(?:\s+
 (?&lt;type_name&gt;
   (?:
     (?:
@@ -6118,7 +6118,7 @@
       \s*
     )*
   )
-)\s*
+))?\s*
 (?=\()</string>
         <key>beginCaptures</key>
         <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3653,7 +3653,7 @@ repository:
   "object-creation-expression-with-parameters":
     begin: '''
       (?x)
-      (new)\\s+
+      (new)(?:\\s+
       (?<type_name>
         (?:
           (?:
@@ -3675,7 +3675,7 @@ repository:
             \\s*
           )*
         )
-      )\\s*
+      ))?\\s*
       (?=\\()
     '''
     beginCaptures:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2412,7 +2412,7 @@ repository:
   object-creation-expression-with-parameters:
     begin: |-
       (?x)
-      (new)\s+
+      (new)(?:\s+
       (?<type_name>
         (?:
           (?:
@@ -2434,7 +2434,7 @@ repository:
             \s*
           )*
         )
-      )\s*
+      ))?\s*
       (?=\()
     beginCaptures:
       '1': { name: keyword.other.new.cs }

--- a/test/type-name.tests.ts
+++ b/test/type-name.tests.ts
@@ -307,6 +307,23 @@ describe("Type names", () => {
                 Token.Punctuation.Semicolon]);
         });
 
+        it("assignments target-typed new object creation expression", async () => {
+            const input = Input.InMethod(`List<int> x = new();`);
+            const tokens = await tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Type("List"),
+                Token.Punctuation.TypeParameters.Begin,
+                Token.PrimitiveType.Int,
+                Token.Punctuation.TypeParameters.End,
+                Token.Identifiers.LocalName("x"),
+                Token.Operators.Assignment,
+                Token.Keywords.New,
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Punctuation.Semicolon]);
+        });
+
         it("assignments new array creation expression", async () => {
             const input = Input.InMethod(`x = new string[4];`);
             const tokens = await tokenize(input);


### PR DESCRIPTION
Target-typed new keyword is currently classified incorrectly as a method call.

Related #232, #239