### PR TITLE
Highlight builtin type keywords

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -409,6 +409,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#type-builtin</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#this-or-base-expression</string>
           </dict>
           <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -289,6 +289,9 @@ repository:
         include: "#verbatim-interpolated-string"
       }
       {
+        include: "#type-builtin"
+      }
+      {
         include: "#this-or-base-expression"
       }
       {

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -117,6 +117,7 @@ repository:
     - include: '#raw-interpolated-string'
     - include: '#interpolated-string'
     - include: '#verbatim-interpolated-string'
+    - include: '#type-builtin'
     - include: '#this-or-base-expression'
     - include: '#switch-expression'
     - include: '#conditional-operator'

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -4591,7 +4591,7 @@ select x.Key1;`);
           Token.Identifiers.LocalName("b"),
           Token.Keywords.Control.When,
           Token.Punctuation.OpenParen,
-          Token.Variables.ReadWrite("double"),
+          Token.PrimitiveType.Double,
           Token.Punctuation.CloseParen,
           Token.Variables.Object("b"),
           Token.Punctuation.Accessor,


### PR DESCRIPTION
Built-in type keywords should be highlighted as the same logic as `this` keyword.