### PR TITLE
With expression

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -425,6 +425,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#with-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#conditional-operator</string>
           </dict>
           <dict>
@@ -3014,6 +3018,28 @@
                 <string>#punctuation-comma</string>
               </dict>
             </array>
+          </dict>
+        </array>
+      </dict>
+      <key>with-expression</key>
+      <dict>
+        <key>begin</key>
+        <string>(?&lt;!\.)\b(with)\b\s*(?=\{|$)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>keyword.other.with.cs</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?&lt;=\})</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#initializer-expression</string>
           </dict>
         </array>
       </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -301,6 +301,9 @@ repository:
         include: "#switch-expression"
       }
       {
+        include: "#with-expression"
+      }
+      {
         include: "#conditional-operator"
       }
       {
@@ -1882,6 +1885,17 @@ repository:
             include: "#punctuation-comma"
           }
         ]
+      }
+    ]
+  "with-expression":
+    begin: "(?<!\\.)\\b(with)\\b\\s*(?=\\{|$)"
+    beginCaptures:
+      "1":
+        name: "keyword.other.with.cs"
+    end: "(?<=\\})"
+    patterns: [
+      {
+        include: "#initializer-expression"
       }
     ]
   "switch-pattern":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -121,6 +121,7 @@ repository:
     - include: '#type-builtin'
     - include: '#this-or-base-expression'
     - include: '#switch-expression'
+    - include: '#with-expression'
     - include: '#conditional-operator'
     - include: '#expression-operators'
     - include: '#await-expression'
@@ -1119,6 +1120,14 @@ repository:
       - include: '#switch-pattern'
       - include: '#expression-body'
       - include: '#punctuation-comma'
+
+  with-expression:
+    begin: (?<!\.)\b(with)\b\s*(?=\{|$)
+    beginCaptures:
+      '1': { name: keyword.other.with.cs }
+    end: (?<=\})
+    patterns:
+    - include: '#initializer-expression'
 
   switch-pattern:
     begin: |-

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -4822,5 +4822,65 @@ select x.Key1;`);
         ]);
       });
     });
+
+    describe("With expression", () => {
+      it("single line", async () => {
+        const input = Input.InMethod(`var p2 = p1 with { X = 5 };`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Var,
+          Token.Identifiers.LocalName("p2"),
+          Token.Operators.Assignment,
+          Token.Variables.ReadWrite("p1"),
+          Token.Keywords.With,
+          Token.Punctuation.OpenBrace,
+          Token.Variables.ReadWrite("X"),
+          Token.Operators.Assignment,
+          Token.Literals.Numeric.Decimal("5"),
+          Token.Punctuation.CloseBrace,
+          Token.Punctuation.Semicolon,
+        ]);
+      });
+
+      it("multiple lines", async () => {
+        const input = Input.InMethod(`
+var p2 = p1 with
+{
+  X = 5, // comment
+  Y = new List<int> { 0, 1 }
+};`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Var,
+          Token.Identifiers.LocalName("p2"),
+          Token.Operators.Assignment,
+          Token.Variables.ReadWrite("p1"),
+          Token.Keywords.With,
+          Token.Punctuation.OpenBrace,
+          Token.Variables.ReadWrite("X"),
+          Token.Operators.Assignment,
+          Token.Literals.Numeric.Decimal("5"),
+          Token.Punctuation.Comma,
+          Token.Comment.SingleLine.Start,
+          Token.Comment.SingleLine.Text(" comment"),
+          Token.Variables.ReadWrite("Y"),
+          Token.Operators.Assignment,
+          Token.Keywords.New,
+          Token.Type("List"),
+          Token.Punctuation.TypeParameters.Begin,
+          Token.PrimitiveType.Int,
+          Token.Punctuation.TypeParameters.End,
+          Token.Punctuation.OpenBrace,
+          Token.Literals.Numeric.Decimal("0"),
+          Token.Punctuation.Comma,
+          Token.Literals.Numeric.Decimal("1"),
+          Token.Punctuation.CloseBrace,
+          Token.Punctuation.CloseBrace,
+          Token.Punctuation.Semicolon,
+        ]);
+      });
+    });
   });
 });

--- a/test/utils/tokenize.ts
+++ b/test/utils/tokenize.ts
@@ -368,6 +368,7 @@ export namespace Token {
         export const Using = createToken('using', 'keyword.other.using.cs');
         export const Var = createToken('var', 'keyword.other.var.cs');
         export const Where = createToken('where', 'keyword.other.where.cs');
+        export const With = createToken('with', 'keyword.other.with.cs');
     }
 
     export namespace Literals {


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/with-expression

Syntax is identical to:

- LHS: switch expression `(?<!\.)\b`
- RHS: anonymous object `b\s*(?=\{|$)` +  `#initializer-expression` + `(?<=\})`
- context & op. precedence: switch expression

I chose `keyword.other.with.cs` as it seemed most appropriate, but let me know if there's a better name for it.

Related: #239 