### PR TITLE
Event fields enhancement

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -1898,8 +1898,8 @@
   )\s+
 )
 (?&lt;interface_name&gt;\g&lt;type_name&gt;\s*\.\s*)?
-(?&lt;event_names&gt;\g&lt;identifier&gt;(?:\s*,\s*\g&lt;identifier&gt;)*)\s*
-(?=\{|;|//|/\*|$)</string>
+(\g&lt;identifier&gt;)\s* # first event name
+(?=\{|;|,|=|//|/\*|$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1933,19 +1933,8 @@
           </dict>
           <key>9</key>
           <dict>
-            <key>patterns</key>
-            <array>
-              <dict>
-                <key>name</key>
-                <string>entity.name.variable.event.cs</string>
-                <key>match</key>
-                <string>@?[_[:alpha:]][_[:alnum:]]*</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#punctuation-comma</string>
-              </dict>
-            </array>
+            <key>name</key>
+            <string>entity.name.variable.event.cs</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1961,8 +1950,39 @@
             <string>#event-accessors</string>
           </dict>
           <dict>
+            <key>name</key>
+            <string>entity.name.variable.event.cs</string>
+            <key>match</key>
+            <string>@?[_[:alpha:]][_[:alnum:]]*</string>
+          </dict>
+          <dict>
             <key>include</key>
             <string>#punctuation-comma</string>
+          </dict>
+          <dict>
+            <key>begin</key>
+            <string>=</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>0</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.assignment.cs</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?&lt;=,)|(?=;)</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#expression</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#punctuation-comma</string>
+              </dict>
+            </array>
           </dict>
         </array>
       </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -1226,8 +1226,8 @@ repository:
         )\\s+
       )
       (?<interface_name>\\g<type_name>\\s*\\.\\s*)?
-      (?<event_names>\\g<identifier>(?:\\s*,\\s*\\g<identifier>)*)\\s*
-      (?=\\{|;|//|/\\*|$)
+      (\\g<identifier>)\\s* # first event name
+      (?=\\{|;|,|=|//|/\\*|$)
     '''
     beginCaptures:
       "1":
@@ -1248,15 +1248,7 @@ repository:
           }
         ]
       "9":
-        patterns: [
-          {
-            name: "entity.name.variable.event.cs"
-            match: "@?[_[:alpha:]][_[:alnum:]]*"
-          }
-          {
-            include: "#punctuation-comma"
-          }
-        ]
+        name: "entity.name.variable.event.cs"
     end: "(?<=\\})|(?=;)"
     patterns: [
       {
@@ -1266,7 +1258,26 @@ repository:
         include: "#event-accessors"
       }
       {
+        name: "entity.name.variable.event.cs"
+        match: "@?[_[:alpha:]][_[:alnum:]]*"
+      }
+      {
         include: "#punctuation-comma"
+      }
+      {
+        begin: "="
+        beginCaptures:
+          "0":
+            name: "keyword.operator.assignment.cs"
+        end: "(?<=,)|(?=;)"
+        patterns: [
+          {
+            include: "#expression"
+          }
+          {
+            include: "#punctuation-comma"
+          }
+        ]
       }
     ]
   "property-accessors":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -690,8 +690,8 @@ repository:
         )\s+
       )
       (?<interface_name>\g<type_name>\s*\.\s*)?
-      (?<event_names>\g<identifier>(?:\s*,\s*\g<identifier>)*)\s*
-      (?=\{|;|//|/\*|$)
+      (\g<identifier>)\s* # first event name
+      (?=\{|;|,|=|//|/\*|$)
     beginCaptures:
       '1': { name: keyword.other.event.cs }
       '2':
@@ -706,16 +706,21 @@ repository:
         patterns:
         - include: '#type'
         - include: '#punctuation-accessor'
-      '9':
-        patterns:
-        - name: entity.name.variable.event.cs
-          match: '@?[_[:alpha:]][_[:alnum:]]*'
-        - include: '#punctuation-comma'
+      '9': { name: entity.name.variable.event.cs }
     end: (?<=\})|(?=;)
     patterns:
     - include: '#comment'
     - include: '#event-accessors'
+    - name: entity.name.variable.event.cs
+      match: '@?[_[:alpha:]][_[:alnum:]]*'
     - include: '#punctuation-comma'
+    - begin: '='
+      beginCaptures:
+        '0': { name: keyword.operator.assignment.cs }
+      end: (?<=,)|(?=;)
+      patterns:
+      - include: '#expression'
+      - include: '#punctuation-comma'
 
   property-accessors:
     begin: \{

--- a/test/event.tests.ts
+++ b/test/event.tests.ts
@@ -288,5 +288,50 @@ event EventHandler Event // comment
                 Token.Punctuation.CloseBrace,
             ]);
         });
+
+        it("declaration with default value (issue #118)", async () => {
+            const input = Input.InClass(`event EventHandler Event = null;`);
+            const tokens = await tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Event,
+                Token.Type("EventHandler"),
+                Token.Identifiers.EventName("Event"),
+                Token.Operators.Assignment,
+                Token.Literals.Null,
+                Token.Punctuation.Semicolon,
+            ]);
+        });
+
+        it("multiple declarations with default value (issue #118)", async () => {
+            const input = Input.InClass(`
+event EventHandler Event1 = delegate { },
+                   Event2 = () => { }
+                   , Event3 = null;`);
+            const tokens = await tokenize(input);
+
+            tokens.should.deep.equal([
+                Token.Keywords.Event,
+                Token.Type("EventHandler"),
+                Token.Identifiers.EventName("Event1"),
+                Token.Operators.Assignment,
+                Token.Keywords.Delegate,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace,
+                Token.Punctuation.Comma,
+                Token.Identifiers.EventName("Event2"),
+                Token.Operators.Assignment,
+                Token.Punctuation.OpenParen,
+                Token.Punctuation.CloseParen,
+                Token.Operators.Arrow,
+                Token.Punctuation.OpenBrace,
+                Token.Punctuation.CloseBrace,
+                Token.Punctuation.Comma,
+                Token.Identifiers.EventName("Event3"),
+                Token.Operators.Assignment,
+                Token.Literals.Null,
+                Token.Punctuation.Semicolon,
+            ]);
+        });
     });
 });


### PR DESCRIPTION
- multiple event fields across multiple lines
- default value assignment of each event field

fixes #118 

P.S. All these PRs because the semantic highlighter marks every single keyword as `plainKeyword` which overrides everything as `keyword.cs`, even if it already had more specific scope like `keyword.other.X.Y.cs`.
I just wanted separate colours for some special keywords so I turned off theme colour for `keyword.cs` and this happens...