### PR TITLE
Fix as before null-coalescing operator

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6034,14 +6034,12 @@
       (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
       (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
     )
-    (?:\s*\?\s*)? # nullable suffix?
+    (?:\s*\?(?!\?))? # nullable suffix?
     (?:\s* # array suffix?
       \[
-        (?:\s*,\s*)* # commata for multi-dimensional arrays
+        \s*(?:,\s*)* # commata for multi-dimensional arrays
       \]
-      \s*
-      (?:\?)? # arrays can be nullable reference types
-      \s*
+      (?:\s*\?(?!\?))? # arrays can be nullable reference types
     )*
   )
 )?</string>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3587,14 +3587,12 @@ repository:
             (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
           )
-          (?:\\s*\\?\\s*)? # nullable suffix?
+          (?:\\s*\\?(?!\\?))? # nullable suffix?
           (?:\\s* # array suffix?
             \\[
-              (?:\\s*,\\s*)* # commata for multi-dimensional arrays
+              \\s*(?:,\\s*)* # commata for multi-dimensional arrays
             \\]
-            \\s*
-            (?:\\?)? # arrays can be nullable reference types
-            \\s*
+            (?:\\s*\\?(?!\\?))? # arrays can be nullable reference types
           )*
         )
       )?

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2340,14 +2340,12 @@ repository:
             (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
             (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
           )
-          (?:\s*\?\s*)? # nullable suffix?
+          (?:\s*\?(?!\?))? # nullable suffix?
           (?:\s* # array suffix?
             \[
-              (?:\s*,\s*)* # commata for multi-dimensional arrays
+              \s*(?:,\s*)* # commata for multi-dimensional arrays
             \]
-            \s*
-            (?:\?)? # arrays can be nullable reference types
-            \s*
+            (?:\s*\?(?!\?))? # arrays can be nullable reference types
           )*
         )
       )?

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -1681,7 +1681,7 @@ var x = new // comment
       });
 
       it("as type ?? (issue #245)", async () => {
-        const input = Input.InMethod(`var a = b as string ?? "";`)
+        const input = Input.InMethod(`var a = b as string ?? "";`);
         const tokens = await tokenize(input);
 
         tokens.should.deep.equal([
@@ -1695,11 +1695,11 @@ var x = new // comment
           Token.Punctuation.String.Begin,
           Token.Punctuation.String.End,
           Token.Punctuation.Semicolon,
-        ])
+        ]);
       });
 
       it("as type? ?? (issue #245)", async () => {
-        const input = Input.InMethod(`var a = b as int? ?? 0;`)
+        const input = Input.InMethod(`var a = b as int? ?? 0;`);
         const tokens = await tokenize(input);
 
         tokens.should.deep.equal([
@@ -1713,11 +1713,11 @@ var x = new // comment
           Token.Operators.NullCoalescing,
           Token.Literals.Numeric.Decimal("0"),
           Token.Punctuation.Semicolon,
-        ])
+        ]);
       });
 
       it("as type[] ?? (issue #245)", async () => {
-        const input = Input.InMethod(`var a = b as int[] ?? new int[0];`)
+        const input = Input.InMethod(`var a = b as int[] ?? new int[0];`);
         const tokens = await tokenize(input);
 
         tokens.should.deep.equal([
@@ -1736,8 +1736,9 @@ var x = new // comment
           Token.Literals.Numeric.Decimal("0"),
           Token.Punctuation.CloseBracket,
           Token.Punctuation.Semicolon,
-        ])
+        ]);
       });
+    });
 
     describe("Checked/Unchecked", () => {
       it("checked expression", async () => {

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -1679,7 +1679,65 @@ var x = new // comment
           Token.Punctuation.Semicolon
         ]);
       });
-    });
+
+      it("as type ?? (issue #245)", async () => {
+        const input = Input.InMethod(`var a = b as string ?? "";`)
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Var,
+          Token.Identifiers.LocalName("a"),
+          Token.Operators.Assignment,
+          Token.Variables.ReadWrite("b"),
+          Token.Keywords.As,
+          Token.PrimitiveType.String,
+          Token.Operators.NullCoalescing,
+          Token.Punctuation.String.Begin,
+          Token.Punctuation.String.End,
+          Token.Punctuation.Semicolon,
+        ])
+      });
+
+      it("as type? ?? (issue #245)", async () => {
+        const input = Input.InMethod(`var a = b as int? ?? 0;`)
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Var,
+          Token.Identifiers.LocalName("a"),
+          Token.Operators.Assignment,
+          Token.Variables.ReadWrite("b"),
+          Token.Keywords.As,
+          Token.PrimitiveType.Int,
+          Token.Punctuation.QuestionMark,
+          Token.Operators.NullCoalescing,
+          Token.Literals.Numeric.Decimal("0"),
+          Token.Punctuation.Semicolon,
+        ])
+      });
+
+      it("as type[] ?? (issue #245)", async () => {
+        const input = Input.InMethod(`var a = b as int[] ?? new int[0];`)
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Keywords.Var,
+          Token.Identifiers.LocalName("a"),
+          Token.Operators.Assignment,
+          Token.Variables.ReadWrite("b"),
+          Token.Keywords.As,
+          Token.PrimitiveType.Int,
+          Token.Punctuation.OpenBracket,
+          Token.Punctuation.CloseBracket,
+          Token.Operators.NullCoalescing,
+          Token.Keywords.New,
+          Token.PrimitiveType.Int,
+          Token.Punctuation.OpenBracket,
+          Token.Literals.Numeric.Decimal("0"),
+          Token.Punctuation.CloseBracket,
+          Token.Punctuation.Semicolon,
+        ])
+      });
 
     describe("Checked/Unchecked", () => {
       it("checked expression", async () => {


### PR DESCRIPTION
All other uses of this type detection don't seem to need this treatment (doesn't allow `??` operator immediately after).

Fixes #245 