### PR TITLE
local function modifiers

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -4323,11 +4323,92 @@
       </dict>
       <key>local-function-declaration</key>
       <dict>
+        <key>begin</key>
+        <string>(?x)
+\b((?:(?:async|unsafe|static|extern)\s+)*)
+(?&lt;type_name&gt;
+  (?:ref\s+(?:readonly\s+)?)?   # ref return
+  (?:
+    (?:(?&lt;identifier&gt;@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+    (?&lt;name_and_type_args&gt; # identifier + type arguments (if any)
+      \g&lt;identifier&gt;\s*
+      (?&lt;type_args&gt;\s*&lt;(?:[^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?
+    )
+    (?:\s*\.\s*\g&lt;name_and_type_args&gt;)* | # Are there any more names being dotted into?
+    (?&lt;tuple&gt;\s*\((?:[^\(\)]|\g&lt;tuple&gt;)+\))
+  )
+  (?:\s*\?)? # nullable suffix?
+  (?:\s* # array suffix?
+    \[
+      \s*(?:,\s*)* # commata for multi-dimensional arrays
+    \]
+    (?:\s*\?)? # arrays can be nullable reference types
+  )*
+)\s+
+(\g&lt;identifier&gt;)\s*
+(&lt;[^&lt;&gt;]+&gt;)?\s*
+(?=\()</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#storage-modifier</string>
+              </dict>
+            </array>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type</string>
+              </dict>
+            </array>
+          </dict>
+          <key>7</key>
+          <dict>
+            <key>name</key>
+            <string>entity.name.function.cs</string>
+          </dict>
+          <key>8</key>
+          <dict>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type-parameter-list</string>
+              </dict>
+            </array>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(?&lt;=\})|(?=;)</string>
         <key>patterns</key>
         <array>
           <dict>
             <key>include</key>
-            <string>#method-declaration</string>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#parenthesized-parameter-list</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#generic-constraints</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#expression-body</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#block</string>
           </dict>
         </array>
       </dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2664,9 +2664,69 @@ repository:
       }
     ]
   "local-function-declaration":
+    begin: '''
+      (?x)
+      \\b((?:(?:async|unsafe|static|extern)\\s+)*)
+      (?<type_name>
+        (?:ref\\s+(?:readonly\\s+)?)?   # ref return
+        (?:
+          (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\\s*\\:\\:\\s*)? # alias-qualification
+          (?<name_and_type_args> # identifier + type arguments (if any)
+            \\g<identifier>\\s*
+            (?<type_args>\\s*<(?:[^<>]|\\g<type_args>)+>\\s*)?
+          )
+          (?:\\s*\\.\\s*\\g<name_and_type_args>)* | # Are there any more names being dotted into?
+          (?<tuple>\\s*\\((?:[^\\(\\)]|\\g<tuple>)+\\))
+        )
+        (?:\\s*\\?)? # nullable suffix?
+        (?:\\s* # array suffix?
+          \\[
+            \\s*(?:,\\s*)* # commata for multi-dimensional arrays
+          \\]
+          (?:\\s*\\?)? # arrays can be nullable reference types
+        )*
+      )\\s+
+      (\\g<identifier>)\\s*
+      (<[^<>]+>)?\\s*
+      (?=\\()
+    '''
+    beginCaptures:
+      "1":
+        patterns: [
+          {
+            include: "#storage-modifier"
+          }
+        ]
+      "2":
+        patterns: [
+          {
+            include: "#type"
+          }
+        ]
+      "7":
+        name: "entity.name.function.cs"
+      "8":
+        patterns: [
+          {
+            include: "#type-parameter-list"
+          }
+        ]
+    end: "(?<=\\})|(?=;)"
     patterns: [
       {
-        include: "#method-declaration"
+        include: "#comment"
+      }
+      {
+        include: "#parenthesized-parameter-list"
+      }
+      {
+        include: "#generic-constraints"
+      }
+      {
+        include: "#expression-body"
+      }
+      {
+        include: "#block"
       }
     ]
   "local-tuple-var-deconstruction":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1657,8 +1657,49 @@ repository:
     - include: '#variable-initializer'
 
   local-function-declaration:
+    begin: |-
+      (?x)
+      \b((?:(?:async|unsafe|static|extern)\s+)*)
+      (?<type_name>
+        (?:ref\s+(?:readonly\s+)?)?   # ref return
+        (?:
+          (?:(?<identifier>@?[_[:alpha:]][_[:alnum:]]*)\s*\:\:\s*)? # alias-qualification
+          (?<name_and_type_args> # identifier + type arguments (if any)
+            \g<identifier>\s*
+            (?<type_args>\s*<(?:[^<>]|\g<type_args>)+>\s*)?
+          )
+          (?:\s*\.\s*\g<name_and_type_args>)* | # Are there any more names being dotted into?
+          (?<tuple>\s*\((?:[^\(\)]|\g<tuple>)+\))
+        )
+        (?:\s*\?)? # nullable suffix?
+        (?:\s* # array suffix?
+          \[
+            \s*(?:,\s*)* # commata for multi-dimensional arrays
+          \]
+          (?:\s*\?)? # arrays can be nullable reference types
+        )*
+      )\s+
+      (\g<identifier>)\s*
+      (<[^<>]+>)?\s*
+      (?=\()
+    beginCaptures:
+      '1':
+        patterns:
+        - include: '#storage-modifier'
+      '2':
+        patterns:
+        - include: '#type'
+      '7': { name: entity.name.function.cs }
+      '8':
+        patterns:
+        - include: '#type-parameter-list'
+    end: (?<=\})|(?=;)
     patterns:
-      - include: '#method-declaration'
+    - include: '#comment'
+    - include: '#parenthesized-parameter-list'
+    - include: '#generic-constraints'
+    - include: '#expression-body'
+    - include: '#block'
 
   local-tuple-var-deconstruction:
     begin: |-

--- a/test/local.tests.ts
+++ b/test/local.tests.ts
@@ -9,7 +9,7 @@ import { tokenize, Input, Token } from './utils/tokenize';
 describe("Locals", () => {
     before(() => { should(); });
 
-    describe("Locals", () => {
+    describe("Local variables", () => {
         it("declaration", async () => {
             const input = Input.InMethod(`int x;`);
             const tokens = await tokenize(input);
@@ -167,9 +167,11 @@ describe("Locals", () => {
                 Token.Punctuation.Semicolon
             ]);
         });
+    });
 
+    describe("Local functions", () => {
         it("local function declaration with arrow body", async () => {
-            const input = Input.InClass(`nuint Add(nuint x, uint y) => x + y;`);
+            const input = Input.InMethod(`nuint Add(nuint x, uint y) => x + y;`);
             const tokens = await tokenize(input);
 
             tokens.should.deep.equal([
@@ -219,7 +221,7 @@ int Add(int x, int y)
         });
 
         it("local function declaration with async modifier", async () => {
-            const input = Input.InClass(`async void Foo() { }`);
+            const input = Input.InMethod(`async void Foo() { }`);
             const tokens = await tokenize(input);
 
             tokens.should.deep.equal([
@@ -234,7 +236,7 @@ int Add(int x, int y)
         });
 
         it("local function declaration with unsafe modifier", async () => {
-            const input = Input.InClass(`unsafe void Foo() { }`);
+            const input = Input.InMethod(`unsafe void Foo() { }`);
             const tokens = await tokenize(input);
 
             tokens.should.deep.equal([
@@ -249,7 +251,7 @@ int Add(int x, int y)
         });
 
         it("local function declaration with static modifier", async () => {
-            const input = Input.InClass(`static void Foo() { }`);
+            const input = Input.InMethod(`static void Foo() { }`);
             const tokens = await tokenize(input);
 
             tokens.should.deep.equal([
@@ -264,7 +266,7 @@ int Add(int x, int y)
         });
 
         it("local function declaration with extern modifier", async () => {
-            const input = Input.InClass(`extern static void Foo() { }`);
+            const input = Input.InMethod(`extern static void Foo() { }`);
             const tokens = await tokenize(input);
 
             tokens.should.deep.equal([


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/local-functions#local-function-syntax

> You can use the following modifiers with a local function:
> 
> - [async](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/async)
> - [unsafe](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/unsafe)
> - [static](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/static) A static local function can't capture local variables or instance state.
> - [extern](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/extern) An external local function must be static.