### PR TITLE
End incomplete statements in block

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -2759,7 +2759,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=;)</string>
+        <string>(?=[;}])</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -2816,7 +2816,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=;)</string>
+        <string>(?=[;}])</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -2860,7 +2860,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=;)</string>
+        <string>(?=[;}])</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -2901,7 +2901,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=;)</string>
+        <string>(?=[;}])</string>
         <key>patterns</key>
         <array>
           <dict>
@@ -2941,7 +2941,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=;)</string>
+        <string>(?=[;}])</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -2774,7 +2774,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=;)</string>
+            <string>(?=[;}])</string>
             <key>patterns</key>
             <array>
               <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -1757,7 +1757,7 @@ repository:
         beginCaptures:
           "1":
             name: "keyword.control.case.cs"
-        end: "(?=;)"
+        end: "(?=[;}])"
         patterns: [
           {
             include: "#expression"

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -1750,7 +1750,7 @@ repository:
     beginCaptures:
       "1":
         name: "keyword.control.goto.cs"
-    end: "(?=;)"
+    end: "(?=[;}])"
     patterns: [
       {
         begin: "\\b(case)\\b"
@@ -1780,7 +1780,7 @@ repository:
     beginCaptures:
       "1":
         name: "keyword.control.flow.return.cs"
-    end: "(?=;)"
+    end: "(?=[;}])"
     patterns: [
       {
         include: "#ref-modifier"
@@ -1801,7 +1801,7 @@ repository:
     beginCaptures:
       "1":
         name: "keyword.control.flow.throw.cs"
-    end: "(?=;)"
+    end: "(?=[;}])"
     patterns: [
       {
         include: "#expression"
@@ -1823,7 +1823,7 @@ repository:
         name: "keyword.control.flow.yield.cs"
       "2":
         name: "keyword.control.flow.return.cs"
-    end: "(?=;)"
+    end: "(?=[;}])"
     patterns: [
       {
         include: "#expression"
@@ -1841,7 +1841,7 @@ repository:
     beginCaptures:
       "1":
         name: "keyword.other.await.cs"
-    end: "(?=;)"
+    end: "(?=[;}])"
     patterns: [
       {
         include: "#statement"

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1037,7 +1037,7 @@ repository:
     - begin: \b(case)\b
       beginCaptures:
         '1': { name: keyword.control.case.cs }
-      end: (?=;)
+      end: (?=[;}])
       patterns:
       - include: '#expression'
     - match: \b(default)\b

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1032,7 +1032,7 @@ repository:
     begin: (?<!\.)\b(goto)\b
     beginCaptures:
       '1': { name: keyword.control.goto.cs }
-    end: (?=;)
+    end: (?=[;}])
     patterns:
     - begin: \b(case)\b
       beginCaptures:
@@ -1050,7 +1050,7 @@ repository:
     begin: (?<!\.)\b(return)\b
     beginCaptures:
       '1': { name: keyword.control.flow.return.cs }
-    end: (?=;)
+    end: (?=[;}])
     patterns:
     - include: '#ref-modifier'
     - include: '#expression'
@@ -1065,7 +1065,7 @@ repository:
     begin: (?<!\.)\b(throw)\b
     beginCaptures:
       '1': { name: keyword.control.flow.throw.cs }
-    end: (?=;)
+    end: (?=[;}])
     patterns:
     - include: '#expression'
 
@@ -1079,7 +1079,7 @@ repository:
     beginCaptures:
       '1': { name: keyword.control.flow.yield.cs }
       '2': { name: keyword.control.flow.return.cs }
-    end: (?=;)
+    end: (?=[;}])
     patterns:
     - include: '#expression'
 
@@ -1095,7 +1095,7 @@ repository:
     begin: (?<!\.)\b(await)\b
     beginCaptures:
       '1': { name: keyword.other.await.cs }
-    end: (?=;)
+    end: (?=[;}])
     patterns:
     - include: '#statement'
 


### PR DESCRIPTION
Incomplete statements in a method (or a block) should not destroy syntax highlighting of all following lines outside of the current block.