### PR TITLE
Allow comment in switch statement

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -3040,6 +3040,10 @@
         <key>patterns</key>
         <array>
           <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
             <key>begin</key>
             <string>\(</string>
             <key>beginCaptures</key>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -1892,6 +1892,9 @@ repository:
     end: "(?<=\\})"
     patterns: [
       {
+        include: "#comment"
+      }
+      {
         begin: "\\("
         beginCaptures:
           "0":

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1129,6 +1129,7 @@ repository:
       '1': { name: keyword.control.switch.cs }
     end: (?<=\})
     patterns:
+    - include: '#comment'
     - begin: \(
       beginCaptures:
         '0': { name: punctuation.parenthesis.open.cs }

--- a/test/statements.tests.ts
+++ b/test/statements.tests.ts
@@ -657,6 +657,31 @@ switch (i) {
                     Token.Punctuation.CloseBrace
                 ]);
             });
+            
+            it("switch statement with comment (issue #145)", async () => {
+                const input = Input.InMethod(`
+switch (i) /* comment */ {
+default:
+    break;
+}`);
+                const tokens = await tokenize(input);
+
+                tokens.should.deep.equal([
+                    Token.Keywords.Control.Switch,
+                    Token.Punctuation.OpenParen,
+                    Token.Variables.ReadWrite("i"),
+                    Token.Punctuation.CloseParen,
+                    Token.Comment.MultiLine.Start,
+                    Token.Comment.MultiLine.Text(" comment "),
+                    Token.Comment.MultiLine.End,
+                    Token.Punctuation.OpenBrace,
+                    Token.Keywords.Control.Default,
+                    Token.Punctuation.Colon,
+                    Token.Keywords.Control.Break,
+                    Token.Punctuation.Semicolon,
+                    Token.Punctuation.CloseBrace
+                ]);
+            });
         });
 
         describe("Try", () => {


### PR DESCRIPTION
Fixes #145 

Still does not allow comment between `switch` and `(variable)` though, because of switch expressions.