### PR TITLE
Fix generic method invocation

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -6222,7 +6222,15 @@
   (-&gt;)\s*                                         # preceding pointer arrow?
 )?
 (@?[_[:alpha:]][_[:alnum:]]*)\s*                  # method name
-(?&lt;type_args&gt;\s*&lt;([^&lt;&gt;]|\g&lt;type_args&gt;)+&gt;\s*)?\s*  # type arguments
+(
+  &lt;
+  (?&lt;type_args&gt;
+    [^&lt;&gt;()]+|
+    &lt;\g&lt;type_args&gt;+&gt;|
+    \(\g&lt;type_args&gt;+\)
+  )+
+  &gt;\s*
+)?                                                # type arguments
 (?=\()                                            # open paren of argument list</string>
         <key>beginCaptures</key>
         <dict>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -3727,7 +3727,15 @@ repository:
         (->)\\s*                                         # preceding pointer arrow?
       )?
       (@?[_[:alpha:]][_[:alnum:]]*)\\s*                  # method name
-      (?<type_args>\\s*<([^<>]|\\g<type_args>)+>\\s*)?\\s*  # type arguments
+      (
+        <
+        (?<type_args>
+          [^<>()]+|
+          <\\g<type_args>+>|
+          \\(\\g<type_args>+\\)
+        )+
+        >\\s*
+      )?                                                # type arguments
       (?=\\()                                            # open paren of argument list
     '''
     beginCaptures:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -2445,7 +2445,15 @@ repository:
         (->)\s*                                         # preceding pointer arrow?
       )?
       (@?[_[:alpha:]][_[:alnum:]]*)\s*                  # method name
-      (?<type_args>\s*<([^<>]|\g<type_args>)+>\s*)?\s*  # type arguments
+      (
+        <
+        (?<type_args>
+          [^<>()]+|
+          <\g<type_args>+>|
+          \(\g<type_args>+\)
+        )+
+        >\s*
+      )?                                                # type arguments
       (?=\()                                            # open paren of argument list
     beginCaptures:
       '1': { name: keyword.operator.null-conditional.cs }

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -2721,7 +2721,8 @@ long total = (data["bonusGame"]["win"].AsLong) * data["bonusGame"]["betMult"].As
         const input = Input.InMethod(`
 v = (a << b) >> (c);
 f(A<B,C>(D+E));
-f(A<B,(C>(D+E)));`);
+f(A<B,(C>(D+E)));
+f(A<(B,C)>(D+E));`);
         const tokens = await tokenize(input);
 
         tokens.should.deep.equal([
@@ -2768,6 +2769,24 @@ f(A<B,(C>(D+E)));`);
           Token.Operators.Arithmetic.Addition,
           Token.Variables.ReadWrite("E"),
           Token.Punctuation.CloseParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon,
+
+          Token.Identifiers.MethodName("f"),
+          Token.Punctuation.OpenParen,
+          Token.Identifiers.MethodName("A"),
+          Token.Punctuation.TypeParameters.Begin,
+          Token.Punctuation.OpenParen,
+          Token.Type("B"),
+          Token.Punctuation.Comma,
+          Token.Type("C"),
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.TypeParameters.End,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("D"),
+          Token.Operators.Arithmetic.Addition,
+          Token.Variables.ReadWrite("E"),
           Token.Punctuation.CloseParen,
           Token.Punctuation.CloseParen,
           Token.Punctuation.Semicolon,

--- a/test/expressions.tests.ts
+++ b/test/expressions.tests.ts
@@ -2717,6 +2717,63 @@ long total = (data["bonusGame"]["win"].AsLong) * data["bonusGame"]["betMult"].As
         ]);
       });
 
+      it("generic with parentheses (issue #200)", async () => {
+        const input = Input.InMethod(`
+v = (a << b) >> (c);
+f(A<B,C>(D+E));
+f(A<B,(C>(D+E)));`);
+        const tokens = await tokenize(input);
+
+        tokens.should.deep.equal([
+          Token.Variables.ReadWrite("v"),
+          Token.Operators.Assignment,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("a"),
+          Token.Operators.Bitwise.ShiftLeft,
+          Token.Variables.ReadWrite("b"),
+          Token.Punctuation.CloseParen,
+          Token.Operators.Bitwise.ShiftRight,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("c"),
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon,
+
+          Token.Identifiers.MethodName("f"),
+          Token.Punctuation.OpenParen,
+          Token.Identifiers.MethodName("A"),
+          Token.Punctuation.TypeParameters.Begin,
+          Token.Type("B"),
+          Token.Punctuation.Comma,
+          Token.Type("C"),
+          Token.Punctuation.TypeParameters.End,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("D"),
+          Token.Operators.Arithmetic.Addition,
+          Token.Variables.ReadWrite("E"),
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon,
+
+          Token.Identifiers.MethodName("f"),
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("A"),
+          Token.Operators.Relational.LessThan,
+          Token.Variables.ReadWrite("B"),
+          Token.Punctuation.Comma,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("C"),
+          Token.Operators.Relational.GreaterThan,
+          Token.Punctuation.OpenParen,
+          Token.Variables.ReadWrite("D"),
+          Token.Operators.Arithmetic.Addition,
+          Token.Variables.ReadWrite("E"),
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.CloseParen,
+          Token.Punctuation.Semicolon,
+        ]);
+      });
+
       it("member of generic with no arguments", async () => {
         const input = Input.InMethod(`C<int>.M();`);
         const tokens = await tokenize(input);


### PR DESCRIPTION
Before:
![image](https://github.com/dotnet/csharp-tmLanguage/assets/13545633/5e949a61-fba7-4fcb-988a-ea1488b7cd96)

After:
![image](https://github.com/dotnet/csharp-tmLanguage/assets/13545633/2a77866f-593f-44bb-ac72-3188ab671b5b)

Fixes #200 

A better fix is to break down the patterns so not everything has to be in one line (similar to https://github.com/dotnet/csharp-tmLanguage/issues/77#issuecomment-1669123012), but for now at least this should fix the issue.