### PR TITLE
Allow more constant patterns

### DIFF
--- a/grammars/csharp.tmLanguage
+++ b/grammars/csharp.tmLanguage
@@ -3420,6 +3420,14 @@
             <key>include</key>
             <string>#verbatim-string-literal</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#typeof-or-default-expression</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#nameof-expression</string>
+          </dict>
         </array>
       </dict>
       <key>relational-pattern</key>
@@ -5148,20 +5156,15 @@
       <key>typeof-or-default-expression</key>
       <dict>
         <key>begin</key>
-        <string>(?&lt;!\.)\b(?:(typeof)|(default))\b\s*(\()</string>
+        <string>(?&lt;!\.)\b(typeof|default)\b\s*(\()</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>keyword.other.typeof.cs</string>
+            <string>keyword.other.$1.cs</string>
           </dict>
           <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>keyword.other.default.cs</string>
-          </dict>
-          <key>3</key>
           <dict>
             <key>name</key>
             <string>punctuation.parenthesis.open.cs</string>

--- a/grammars/csharp.tmLanguage.cson
+++ b/grammars/csharp.tmLanguage.cson
@@ -2116,6 +2116,12 @@ repository:
       {
         include: "#verbatim-string-literal"
       }
+      {
+        include: "#typeof-or-default-expression"
+      }
+      {
+        include: "#nameof-expression"
+      }
     ]
   "relational-pattern":
     begin: "<=?|>=?"
@@ -3174,13 +3180,11 @@ repository:
       }
     ]
   "typeof-or-default-expression":
-    begin: "(?<!\\.)\\b(?:(typeof)|(default))\\b\\s*(\\()"
+    begin: "(?<!\\.)\\b(typeof|default)\\b\\s*(\\()"
     beginCaptures:
       "1":
-        name: "keyword.other.typeof.cs"
+        name: "keyword.other.$1.cs"
       "2":
-        name: "keyword.other.default.cs"
-      "3":
         name: "punctuation.parenthesis.open.cs"
     end: "\\)"
     endCaptures:

--- a/src/csharp.tmLanguage.yml
+++ b/src/csharp.tmLanguage.yml
@@ -1252,6 +1252,8 @@ repository:
     - include: '#string-literal'
     - include: '#raw-string-literal'
     - include: '#verbatim-string-literal'
+    - include: '#typeof-or-default-expression'
+    - include: '#nameof-expression'
 
   relational-pattern:
     begin: <=?|>=?
@@ -1964,11 +1966,10 @@ repository:
     - include: '#expression'
 
   typeof-or-default-expression:
-    begin: (?<!\.)\b(?:(typeof)|(default))\b\s*(\()
+    begin: (?<!\.)\b(typeof|default)\b\s*(\()
     beginCaptures:
-      '1': { name: keyword.other.typeof.cs }
-      '2': { name: keyword.other.default.cs }
-      '3': { name: punctuation.parenthesis.open.cs }
+      '1': { name: keyword.other.$1.cs }
+      '2': { name: punctuation.parenthesis.open.cs }
     end: \)
     endCaptures:
       '0': { name: punctuation.parenthesis.close.cs }

--- a/test/patterns.tests.ts
+++ b/test/patterns.tests.ts
@@ -29,6 +29,8 @@ if (var is 0) { }
 if (var is null) { }
 if (var is "") { }
 if (var is true) { }
+if (var is nameof(Foo)) { }
+if (var is default(int)) { }
 `);
       const tokens = await tokenize(input);
 
@@ -66,6 +68,30 @@ if (var is true) { }
         Token.Variables.ReadWrite("var"),
         Token.Operators.Pattern.Is,
         Token.Literals.Boolean.True,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Punctuation.CloseBrace,
+
+        Token.Keywords.Control.If,
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite("var"),
+        Token.Operators.Pattern.Is,
+        Token.Keywords.NameOf,
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite("Foo"),
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.CloseParen,
+        Token.Punctuation.OpenBrace,
+        Token.Punctuation.CloseBrace,
+
+        Token.Keywords.Control.If,
+        Token.Punctuation.OpenParen,
+        Token.Variables.ReadWrite("var"),
+        Token.Operators.Pattern.Is,
+        Token.Keywords.Default,
+        Token.Punctuation.OpenParen,
+        Token.PrimitiveType.Int,
+        Token.Punctuation.CloseParen,
         Token.Punctuation.CloseParen,
         Token.Punctuation.OpenBrace,
         Token.Punctuation.CloseBrace,


### PR DESCRIPTION
`default(T)` and `nameof(expr)` are valid constants

`typeof(T)` is not a constant, but highlighting should still be supported as it's a valid expression